### PR TITLE
PI-823: Fixing uninstall hook.

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -16,7 +16,7 @@ if (!defined('ABSPATH')) { // Exit if accessed directly
 
 // ************************************************************** //
 
-// Initialize Global Objects 
+// Initialize Global Objects
 $cloudflareConfig = new CF\Integration\DefaultConfig(file_get_contents('config.js', true));
 $cloudflareLogger = new CF\Integration\DefaultLogger($cloudflareConfig->getValue('debug'));
 $cloudflareDataStore = new CF\WordPress\DataStore($cloudflareLogger);
@@ -49,7 +49,7 @@ register_activation_hook(__FILE__, array($cloudflareHooks, 'activate'));
 register_deactivation_hook(__FILE__, array($cloudflareHooks, 'deactivate'));
 
 // Load Uninstall Script
-register_uninstall_hook(__FILE__, array('\CF\WordPress\Uninstall', 'init'));
+register_uninstall_hook(__FILE__, array('\CF\WordPress\Hooks', 'uninstall'));
 
 // Load AutomaticCache
 add_action('switch_theme', array($cloudflareHooks, 'purgeCache'));

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -131,6 +131,13 @@ class Hooks
         $this->dataStore->clearDataStore();
     }
 
+	public static function uninstall() {
+		$config = new \CF\Integration\DefaultConfig('[]');
+		$logger = new \CF\Integration\DefaultLogger($config->getValue('debug'));
+		$dataStore = new \CF\WordPress\DataStore($logger);
+		$dataStore->clearDataStore();
+	}
+
     public function purgeCache()
     {
         if ($this->isPluginSpecificCacheEnabled()) {


### PR DESCRIPTION
I'm not sure if you can uninstall a plugin without deactivating it first.  If thats the case can't we just delete this hook since `deactivate()` calls `clearDataStore()` as well?