### PR TITLE
#104: Composer Autoloader now requires with absolute path to fix bug …

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use CloudFlare\IpRewrite;
 

--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -1,8 +1,14 @@
 <?php
 
-require_once 'vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 use CloudFlare\IpRewrite;
+
+
+// Exit if accessed directly
+if (!defined('ABSPATH')) {
+	exit;
+}
 
 // Rewrites Cloudflare IP
 $ipRewrite = new IpRewrite();


### PR DESCRIPTION
…when plugin was called through WP-CLI.