### PR TITLE
Map active zone to Primary Domain

### DIFF
--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -21,6 +21,10 @@ class WordPressWrapper
 
     public function getSiteURL()
     {
-        return get_site_url();
+        if(function_exists('domain_mapping_siteurl')){
+            return domain_mapping_siteurl('');
+        } else {
+           return get_site_url();
+        }    
     }
 }

--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -21,7 +21,7 @@ class WordPressWrapper
 
     public function getSiteURL()
     {			
-		$site_url = get_site_url();
+	$site_url = get_site_url();
 		
         if(function_exists('domain_mapping_siteurl')){
             $site_url = domain_mapping_siteurl($site_url);

--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -20,11 +20,13 @@ class WordPressWrapper
     }
 
     public function getSiteURL()
-    {
+    {			
+		$site_url = get_site_url();
+		
         if(function_exists('domain_mapping_siteurl')){
-            return domain_mapping_siteurl('');
-        } else {
-           return get_site_url();
-        }    
+            $site_url = domain_mapping_siteurl($site_url);
+        } 
+		
+        return $site_url;  
     }
 }


### PR DESCRIPTION
When Wordpress MU Domain Mapping is enabled, use the primary domain for current blog, instead of default subdomain.

Example scenario:

| wp-admin | PRIMARY DOMAIN | blog_id |
| --- | --- | --- |
| example.com | example.com | 1 |
| it.example.com | www.example.it | 2 |
| fr.example.com | www.example.fr | 3 |

actually this plugin uses the example.com zone for all the domains.

With this PR the active zone is set to the Primary Domain setup in [Wordpress MU Domain Mapping](https://it.wordpress.org/plugins/wordpress-mu-domain-mapping/).
