### PR TITLE
Purge Post on delete and status transition

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -46,5 +46,7 @@ if (is_admin()) {
     // Load Automatic Cache Purge
     add_action('switch_theme', array($cloudflareHooks, 'purgeCache'));
     add_action('customize_save_after', array($cloudflareHooks, 'purgeCache'));
-    add_action('save_post', array($cloudflareHooks, 'purgePage'));
+    add_action('edit_post', array($cloudflareHooks, 'purgeOnPostUpdate'), 10, 3); //published post update
+    add_action('transition_post_status', array($cloudflareHooks, 'purgeOnPostTransition'), 10 ,3); // new post published or old post unpublished
+		add_action('after_delete_post', array($cloudflareHooks, 'purgeSinglePost')); //post deleted
 }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -145,72 +145,72 @@ class Hooks
             $wp_domain_list = $this->integrationAPI->getDomainList();
             $wp_domain = $wp_domain_list[0];
             if (count($wp_domain) > 0) {
-                $zoneTag = $this->api->getZoneTag($wp_domain);
+				$zoneTag = $this->api->getZoneTag($wp_domain);
 
-            		if ( is_numeric($target_post) ) {
-            			$target_post = get_post( (int)$target_post );
-            		}
+				if ( is_numeric($target_post) ) {
+					$target_post = get_post( (int)$target_post );
+				}
 
                 if ( ! is_a( $target_post, 'WP_Post' ) ) {
                    return false;
                 }
 
-            		$post_url = get_permalink( $target_post );
+				$post_url = get_permalink( $target_post );
 
-            		$urls = array();
+				$urls = array();
 
-                //purge post url and home
-            		array_push( $urls, $post_url, home_url() );
+				//purge post url and home
+				array_push( $urls, $post_url, home_url() );
 
-                //purge all taxonomies terms pages
-            		$post_type = get_post_type( $target_post );
+				//purge all taxonomies terms pages
+				$post_type = get_post_type( $target_post );
 
-            		$taxonomies = get_object_taxonomies( $post_type, 'objects' );
+				$taxonomies = get_object_taxonomies( $post_type, 'objects' );
 
-            		foreach ( $taxonomies as $taxonomy_slug => $taxonomy ){
+				foreach ( $taxonomies as $taxonomy_slug => $taxonomy ){
 
-            			$terms = get_the_terms( $target_post, $taxonomy_slug );
+					$terms = get_the_terms( $target_post, $taxonomy_slug );
 
-            			if ( !empty( $terms ) && ! is_wp_error( $terms ) ) {
-            				foreach ( $terms as $term) {
+					if ( !empty( $terms ) && ! is_wp_error( $terms ) ) {
+						foreach ( $terms as $term) {
 
-            					$term_link = get_term_link( $term );
+							$term_link = get_term_link( $term );
 
-            					if ( ! is_wp_error( $term_link ) ) {
-            						array_push( $urls, $term_link );
-            					}
-            				}
-            			}
-            		}
+							if ( ! is_wp_error( $term_link ) ) {
+								array_push( $urls, $term_link );
+							}
+						}
+					}
+				}
 
-               //purge author pages
-               $post_author = get_post_field('post_author', $target_post->ID);
-                array_push($urls,
-                  get_author_posts_url($post_author),
-                  get_author_feed_link($post_author)
-                );
+			   //purge author pages
+			   $post_author = get_post_field('post_author', $target_post->ID);
+				array_push($urls,
+				  get_author_posts_url($post_author),
+				  get_author_feed_link($post_author)
+				);
 
-                //purge post-type archive pages
-                if (get_post_type_archive_link($post_type) == true) {
-                  array_push($urls,
-                    get_post_type_archive_link($post_type),
-                    get_post_type_archive_feed_link($post_type)
-                  );
-                }
+				//purge post-type archive pages
+				if (get_post_type_archive_link($post_type) == true) {
+				  array_push($urls,
+					get_post_type_archive_link($post_type),
+					get_post_type_archive_feed_link($post_type)
+				  );
+				}
 
-                //purge feeds
-                array_push($urls,
-                  get_bloginfo_rss('rdf_url') ,
-                  get_bloginfo_rss('rss_url') ,
-                  get_bloginfo_rss('rss2_url'),
-                  get_bloginfo_rss('atom_url'),
-                  get_bloginfo_rss('comments_rss2_url'),
-                  get_post_comments_feed_link($target_post->ID)
-                );
+				//purge feeds
+				array_push($urls,
+				  get_bloginfo_rss('rdf_url') ,
+				  get_bloginfo_rss('rss_url') ,
+				  get_bloginfo_rss('rss2_url'),
+				  get_bloginfo_rss('atom_url'),
+				  get_bloginfo_rss('comments_rss2_url'),
+				  get_post_comments_feed_link($target_post->ID)
+				);
 
-            		if ( ('post' == $post_type) && ( 'page' == get_option('show_on_front') ) && get_option( 'page_for_posts' ) ) {
-            			array_push( $urls, get_permalink( get_option( 'page_for_posts' ) ) );
-            		}
+				if ( ('post' == $post_type) && ( 'page' == get_option('show_on_front') ) && get_option( 'page_for_posts' ) ) {
+					array_push( $urls, get_permalink( get_option( 'page_for_posts' ) ) );
+				}
 
                 if( is_ssl() ){
                     $urls = array_merge($urls, array_map( function($url){ return str_replace('https://', 'http://', $url); }, $urls) );

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -126,7 +126,20 @@ class Hooks
         }
     }
 
-    public function purgePage($post_id)
+    public function purgeOnPostTransition($new_status, $old_status, $post) {
+        // purge only on unpublished -> published || published -> unpublished
+        if( ( $new_status != $old_status ) && ( 'publish' == $new_status || 'publish' == $old_status )){
+            $this->purgeSinglePost($post);
+        }
+    }
+
+    public function purgeOnPostUpdate($post_id, $post=null) {
+        if( !wp_is_post_autosave( $post ) &&  !wp_is_post_revision( $post ) && ( 'publish' == get_post_status( $post ) ) ) {
+          $this->purgeSinglePost($post);
+        }
+    }
+
+    public function purgeSinglePost($target_post)
     {
         if ($this->isPluginSpecificCacheEnabled()) {
             $wp_domain_list = $this->integrationAPI->getDomainList();
@@ -134,58 +147,84 @@ class Hooks
             if (count($wp_domain) > 0) {
                 $zoneTag = $this->api->getZoneTag($wp_domain);
 
-		$saved_post = get_post( $post_id );
+            		if ( is_numeric($target_post) ) {
+            			$target_post = get_post( (int)$target_post );
+            		}
 
-		if ( is_a( $saved_post, 'WP_Post' ) == false ) {
-			return false;
-		} 
+                if ( ! is_a( $target_post, 'WP_Post' ) ) {
+                   return false;
+                }
 
-		if (  wp_is_post_autosave( $saved_post ) ||  wp_is_post_revision( $saved_post ) || ( 'publish' != get_post_status( $post_id ) ) ) {
-		    return false;
-		}
+            		$post_url = get_permalink( $target_post );
 
-		$post_url = get_permalink( $saved_post );
+            		$urls = array();
 
-		$urls = array();
+                //purge post url and home
+            		array_push( $urls, $post_url, home_url() );
 
-		array_push( $urls, $post_url );
-		array_push( $urls, home_url() );
-        
-		$post_type = get_post_type( $saved_post );
+                //purge all taxonomies terms pages
+            		$post_type = get_post_type( $target_post );
 
-		$taxonomies = get_object_taxonomies( $post_type, 'objects' );
+            		$taxonomies = get_object_taxonomies( $post_type, 'objects' );
 
-		foreach ( $taxonomies as $taxonomy_slug => $taxonomy ){
+            		foreach ( $taxonomies as $taxonomy_slug => $taxonomy ){
 
-			$terms = get_the_terms( $saved_post, $taxonomy_slug );
+            			$terms = get_the_terms( $target_post, $taxonomy_slug );
 
-			if ( !empty( $terms ) && ! is_wp_error( $terms ) ) {
-				foreach ( $terms as $term) {
+            			if ( !empty( $terms ) && ! is_wp_error( $terms ) ) {
+            				foreach ( $terms as $term) {
 
-					$term_link = get_term_link( $term );
+            					$term_link = get_term_link( $term );
 
-					if ( ! is_wp_error( $term_link ) ) {
-						array_push( $urls, $term_link );
-					}
-				} 
-			}
-		}
-        
-		if ( ('post' == $post_type) && ( 'page' == get_option('show_on_front') ) && get_option( 'page_for_posts' ) ) {
-			array_push( $urls, get_permalink( get_option( 'page_for_posts' ) ) );
-		}
+            					if ( ! is_wp_error( $term_link ) ) {
+            						array_push( $urls, $term_link );
+            					}
+            				}
+            			}
+            		}
+
+               //purge author pages
+               $post_author = get_post_field('post_author', $target_post->ID);
+                array_push($urls,
+                  get_author_posts_url($post_author),
+                  get_author_feed_link($post_author)
+                );
+
+                //purge post-type archive pages
+                if (get_post_type_archive_link($post_type) == true) {
+                  array_push($urls,
+                    get_post_type_archive_link($post_type),
+                    get_post_type_archive_feed_link($post_type)
+                  );
+                }
+
+                //purge feeds
+                array_push($urls,
+                  get_bloginfo_rss('rdf_url') ,
+                  get_bloginfo_rss('rss_url') ,
+                  get_bloginfo_rss('rss2_url'),
+                  get_bloginfo_rss('atom_url'),
+                  get_bloginfo_rss('comments_rss2_url'),
+                  get_post_comments_feed_link($target_post->ID)
+                );
+
+            		if ( ('post' == $post_type) && ( 'page' == get_option('show_on_front') ) && get_option( 'page_for_posts' ) ) {
+            			array_push( $urls, get_permalink( get_option( 'page_for_posts' ) ) );
+            		}
 
                 if( is_ssl() ){
                     $urls = array_merge($urls, array_map( function($url){ return str_replace('https://', 'http://', $url); }, $urls) );
                 }
+
+                apply_filters('cloudflare_purge_post_urls', $urls, $target_post);
 
                 if (isset($zoneTag)) {
                     $this->api->zonePurgeFiles($zoneTag, $urls);
                 }
             }
         }
-    }  	
-	
+    }
+
     protected function isPluginSpecificCacheEnabled()
     {
         $cacheSettingObject = $this->dataStore->getPluginSetting(\CF\API\Plugin::SETTING_PLUGIN_SPECIFIC_CACHE);


### PR DESCRIPTION
New features:

- Single post purge triggers also on post deletion and post [status transition](https://codex.wordpress.org/Post_Status_Transitions).
- Enables purging for feeds, post type archives and author archives.
- Enables `$urls` array filtering via `cloudflare_purge_post_urls` filter


