### PR TITLE
Add .travis.yml for Travis CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+php:
+    #- '5.3'
+    #- '5.4'
+    - '5.5'
+    - '5.6'
+    - '7.0'
+
+#matrix:
+#    fast_finish: true
+
+install:
+    - composer install
+
+script:
+    - composer format
+    - composer test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cloudflare’s Plugin for WordPress
 
+[![Build Status](https://travis-ci.org/cloudflare/Cloudflare-WordPress.svg?branch=master)](https://travis-ci.org/cloudflare/Cloudflare-WordPress)
+
 Cloudflare’s WordPress plugin brings all of the benefits of Cloudflare into your WordPress dashboard for configuration, including a one-click application of default settings specifically optimized for WordPress.
 
 By enabling Cloudflare on your WordPress website, you’ll find performance and security gains such as doubling your page load speeds, DDoS protection, web application firewall with WordPress-specific rulesets, free SSL, and SEO improvements.


### PR DESCRIPTION
Some notes:

1. php/mock requires PHP >= 5.5. I'm not sure what to do in order to test all the supported by cloudflare-WordPress plugin PHP versions, so I skipped 5.3 and 5.4. IMO we should definitely test all supported versions to prevent accidental breakage.
2. I left `fast_finish` out and HHVM.

Finally. before merging this, you will need to add Travis CI to the repo and enable "Build only if .travis.yml is present" in the Travis project's settings.

Until then you can have a quick look https://travis-ci.org/XhmikosR/Cloudflare-WordPress/builds

Fixes #143.