### PR TITLE
WP Client API uses WP_HTTP class instead of Guzzle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Yes, on install and activation the plugin, first time users will be asked to ent
 
 Yes, Cloudflare works with, and helps speed up your site even more, if you have Varnish enabled.
 
-### Why am I getting “Cloudflare plugin requires php5-curl to be installed” error?
-
-Make sure that the php5-curl extension is installed on your system.
-
 ## Support
 
 ### Visit Our Knowledge Base

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     "require": {
         "cloudflare/cf-ip-rewrite": "^1.0.0",
         "cloudflare/cloudflare-plugin-backend": "^1.1",
-        "guzzle/guzzle": "~3.9",
         "symfony/yaml": "~2.6"
     },
     "require-dev": {

--- a/readme.txt
+++ b/readme.txt
@@ -77,10 +77,6 @@ Yes, on install and activation the plugin, first time users will be asked to ent
 
 Yes, Cloudflare works with, and helps speed up your site even more, if you have Varnish enabled.
 
-= Why am I getting “Cloudflare plugin requires php5-curl to be installed” error? =
-
-Make sure that the php5-curl extension is installed on your system.
-
 == Screenshots ==
 
 1. Cloudflare Plugin

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -108,12 +108,6 @@ class Hooks
             wp_die('<p><strong>Cloudflare</strong> plugin requires WordPress version ' . CLOUDFLARE_MIN_WP_VERSION . ' or greater.</p>', 'Plugin Activation Error', array('response' => 200, 'back_link' => true));
         }
 
-        // Guzzle3 depends on php5-curl. If dependency does not exist kill the plugin.
-        if (!extension_loaded('curl')) {
-            deactivate_plugins(basename(CLOUDFLARE_PLUGIN_DIR));
-            wp_die('<p><strong>Cloudflare</strong> plugin requires php5-curl to be installed.</p>', 'Plugin Activation Error', array('response' => 200, 'back_link' => true));
-        }
-
         return true;
     }
 

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -84,4 +84,101 @@ class WordPressClientAPI extends Client
 
         return $this->responseOk($response);
     }
+
+    /**
+     * @param Request $request
+     *
+     * @return array|mixed
+     */
+    public function callAPI(Request $request)
+    {
+
+        $request = $this->beforeSend($request);
+
+        $url = add_query_arg($request->getParameters(), $this->getEndpoint() . $request->getUrl());
+
+        $requestParams = array(
+            'timeout' => 30,
+            'method' => $request->getMethod(),
+            'headers' => $request->getHeaders()
+        );
+
+        $isPaginatable = false;
+        if ($requestParams['method'] === 'GET') {
+            $isPaginatable = true;
+        }
+
+        $mergedResponse = null;
+
+        $currentPage = 1;
+        $totalPages = 1;
+
+        while ($totalPages >= $currentPage) {
+            // Enable pagination
+            if ($isPaginatable) {
+                $params['page'] = $currentPage;
+            }
+
+            if ($requestParams['method'] !== 'GET') {
+                $requestParams['body'] = json_encode($request->getBody());
+                $requestParams['headers']['Content-Type'] = 'application/json';
+            }
+
+            $requestResponse = wp_remote_request($url, $requestParams);
+
+            // Check for connection error
+            if (is_wp_error($requestResponse)) {
+                $errorMessage = $requestResponse->get_error_message();
+
+                $this->logAPICall($this->getAPIClientName(), array_merge(array('type' => 'request', 'path' => $url), $requestParams), true);
+                $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'reason' => $requestResponse->get_error_message(), 'code' => $requestResponse->get_error_code(), 'body' => $errorMessage), true);
+
+                return $this->createAPIError($errorMessage);
+            }
+
+            // Check for response error != 2XX
+            if (wp_remote_retrieve_response_code($requestResponse) > 299) {
+                $errorMessage = wp_remote_retrieve_response_message($requestResponse);
+
+                $this->logAPICall($this->getAPIClientName(), array_merge(array('type' => 'request', 'path' => $url), $requestParams), true);
+                $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'reason' => $errorMessage, 'code' => wp_remote_retrieve_response_code($requestResponse)), true);
+
+                return $this->createAPIError($errorMessage);
+            }
+
+            $response = json_decode(wp_remote_retrieve_body($requestResponse), true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $errorMessage = 'Error decoding client API JSON';
+                $this->logAPICall($errorMessage, array( 'error' => json_last_error() ), true);
+
+                return $this->createAPIError($errorMessage);
+            }
+
+            if (!$this->responseOk($response)) {
+                $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'body' => $response), true);
+            }
+
+            if ($isPaginatable && isset($response['result_info'])) {
+                $totalPages = $response['result_info']['total_pages'];
+
+                if (!isset($mergedResponse)) {
+                    $mergedResponse = $response;
+                } else {
+                    $mergedResponse['result'] = array_merge($mergedResponse['result'], $response['result']);
+
+                    // Notify the frontend that pagination is taken care.
+                    $mergedResponse['result_info']['notify'] = 'Backend has taken care of pagination. Ouput is merged in results.';
+                    $mergedResponse['result_info']['page'] = -1;
+                    $mergedResponse['result_info']['count'] = -1;
+                }
+            } else {
+                $mergedResponse = $response;
+            }
+
+            $currentPage += 1;
+        }
+
+        return $mergedResponse;
+    }
 }


### PR DESCRIPTION
Removes the php-curl dependency.

Fixes #113.

This is #134, formatted, rebased and squashed.