### PR TITLE
Check if constant CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE is defined

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -24,7 +24,7 @@ if ($is_cf) {
 $cloudflareHooks = new \CF\WordPress\Hooks();
 
 // Enable HTTP2 Server Push
-if (CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE) {
+if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE) {
     add_action('init', array($cloudflareHooks, 'http2ServerPushInit'));
 }
 


### PR DESCRIPTION
If the named constant `CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE` is not defined in` wp-config.php` PHP uses it's name as value and enables the feature by default. It also shows warnings. 

Better check if it's defined before.
