### PR TITLE
PI-1058 fixed a bug where domain needed to be lowercased

### DIFF
--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -27,6 +27,6 @@ class WordPressWrapper
             $site_url = domain_mapping_siteurl($site_url);
         }
 
-        return $site_url;
+        return strtolower($site_url);
     }
 }


### PR DESCRIPTION
This is one of the bugs we couldn't find out where `Please select a domain that is provisioned with CloudFlare` was showing. 