### PR TITLE
PI-1062 add purge cache button to wp admin bar

### DIFF
--- a/src/WordPress/ClientActions.php
+++ b/src/WordPress/ClientActions.php
@@ -62,6 +62,9 @@ class ClientActions
                 if ($cf_zone['name'] === $wpDomain) {
                     $found = true;
                     array_push($domain_list, $cf_zone);
+
+                    // Cache Zone Id
+                    $this->dataStore->setZoneIdCache($cf_zone['id']);
                 }
             }
 

--- a/src/WordPress/DataStore.php
+++ b/src/WordPress/DataStore.php
@@ -11,6 +11,7 @@ class DataStore implements DataStoreInterface
     const API_KEY = 'cloudflare_api_key';
     const EMAIL = 'cloudflare_api_email';
     const CACHED_DOMAIN_NAME = 'cloudflare_cached_domain_name';
+    const CACHED_ZONE_ID = 'cloudflare_cached_zone_id';
 
     protected $wordPressWrapper;
 
@@ -59,6 +60,18 @@ class DataStore implements DataStoreInterface
     }
 
     /**
+     * @return bool
+     */
+    public function getClientAPICredentialsExist()
+    {
+        if ($this->getClientV4APIKey() && $this->getCloudFlareEmail()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * @return client v4 api key for current user
      */
     public function getClientV4APIKey()
@@ -85,6 +98,22 @@ class DataStore implements DataStoreInterface
         }
 
         return $cachedDomainName;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getZoneIdCache()
+    {
+        return $this->get(self::CACHED_ZONE_ID);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function setZoneIdCache($zoneId)
+    {
+        return $this->set(self::CACHED_ZONE_ID, $zoneId);
     }
 
     /**

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -73,8 +73,9 @@ class WordPressClientAPI extends Client
     }
 
     /**
-     * @param $urlPattern
-     *
+     * @param $zoneId
+     * @param $body
+     * 
      * @return array
      */
     public function createPageRule($zoneId, $body)
@@ -83,6 +84,42 @@ class WordPressClientAPI extends Client
         $response = $this->callAPI($request);
 
         return $this->responseOk($response);
+    }
+
+    /**
+     * @param $zoneId
+     *
+     * @return array
+     */
+    public function getActivePageRuleList($zoneId)
+    {
+        $request = new Request('GET', 'zones/'.$zoneId.'/pagerules/', array('status' => 'active', 'match' => 'all'), null);
+        $response = $this->callAPI($request);
+
+        return $response;
+    }
+
+    /**
+     * @param $zoneId
+     *
+     * @return bool
+     */
+    public function isCacheEverythingPageRuleExists($zoneId) {
+        $activePageRuleList = $this->getActivePageRuleList($zoneId);
+
+        if ($this->responseOk($activePageRuleList)) {
+            foreach ($activePageRuleList['result'] as $pageRule) {
+                // TODO check if the page rule is for current zone
+                foreach ($pageRule['actions'] as $action) {
+                    error_log(print_r($action, true));
+                    if ($action['id'] === 'cache_level' && $action['value'] === 'cache_everything') {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
There are multiple things going on here. We don't have access to anything outside of plugin page level. We need

- Client v4 API Key
- Check if "cache everything" page rule exists and show to only those users

============================================================

1) Once we have access to API Key, we make page rule request. 
2) To make a page rule request we need to have `zoneId`. That's why I'm caching the zoneId every time the user enters the plugin page. 
3) Once we know the zoneId, we can make a the request and figure out if there is any page rule related which has "Cache Everything" action in it.  

    - TODO: We need to make sure not any page rule but only this zone should have it.
    - TODO: Currently all these checks will run for every single request to the page. We need to limit that to admin login (not admin page)
    - TODO: We need to make sure not to request the API every time the user hangouts in admin page. We need to cache the result of `isCacheEverythingPageRuleExists` function and once in a while (1 day seems good I think. Any ideas?) we need double check if this page rule still exists. 

4) We know cache everything page rule exists, purge cache and alert the user

