### PR TITLE
PI-1072 move autoptimize to purge everything instead of per URL

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -46,16 +46,22 @@ if (is_admin()) {
 }
 
 // Load Automatic Cache Purge
-add_action('switch_theme', array($cloudflareHooks, 'purgeCacheEverything'));
-add_action('customize_save_after', array($cloudflareHooks, 'purgeCacheEverything'));
-
-$cloudflarePurgeActions = array(
+$cloudflarePurgeEverythingActions = array(
     'autoptimize_action_cachepurged',   // Compat with https://wordpress.org/plugins/autoptimize
+    'switch_theme',                     // Switch theme
+    'customize_save_after'              // Edit theme
+);
+
+foreach ($cloudflarePurgeEverythingActions as $action) {
+    add_action($action, array($cloudflareHooks, 'purgeCacheEverything'));
+}
+
+$cloudflarePurgeURLActions = array(
     'deleted_post',                     // Delete a post
     'edit_post',                        // Edit a post - includes leaving comments
     'delete_attachment',                // Delete an attachment - includes re-uploading
 );
 
-foreach ($cloudflarePurgeActions as $action) {
+foreach ($cloudflarePurgeURLActions as $action) {
     add_action($action, array($cloudflareHooks, 'purgeCacheByRevelantURLs'), 10, 2);
 }


### PR DESCRIPTION
This PR will need the article to change:

 https://support.cloudflare.com/hc/en-us/articles/115002708027-What-does-Automatic-Cache-Management-in-the-Cloudflare-Plugin-do-

`autoptimize_action_cachepurged` should be needed to move to cache everything part. 

FYI @IcyApril I'll let you know when a release happens.