### PR TITLE
PI-812: We read request JSON for cloudflare plugin requests after the…

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -23,10 +23,6 @@ if ($isCf) {
 // Initiliaze Hooks class which contains WordPress hook functions
 $cloudflareHooks = new \CF\WordPress\Hooks();
 
-/*
- * php://input can only be read once before PHP 5.6, try to grab it ONLY if the request
- * is coming from the cloudflare proxy
- */
 add_action('plugins_loaded', array($cloudflareHooks, 'getCloudflareRequestJSON'));
 
 // Enable HTTP2 Server Push

--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -24,7 +24,7 @@ if ($isCf) {
 $cloudflareHooks = new \CF\WordPress\Hooks();
 
 /*
- * php://input can only be read once before PHP 5.6, try to grab it IF the request
+ * php://input can only be read once before PHP 5.6, try to grab it ONLY if the request
  * is coming from the cloudflare proxy
  */
 add_action('plugins_loaded', array($cloudflareHooks, 'getCloudflareRequestJSON'));

--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -23,6 +23,12 @@ if ($isCf) {
 // Initiliaze Hooks class which contains WordPress hook functions
 $cloudflareHooks = new \CF\WordPress\Hooks();
 
+/*
+ * php://input can only be read once before PHP 5.6, try to grab it IF the request
+ * is coming from the cloudflare proxy
+ */
+add_action('plugins_loaded', array($cloudflareHooks, 'getCloudflareRequestJSON'));
+
 // Enable HTTP2 Server Push
 if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE) {
     add_action('init', array($cloudflareHooks, 'http2ServerPushInit'));

--- a/index.php
+++ b/index.php
@@ -46,7 +46,7 @@ function RestProxyCallback(opts) {
         }
 
         // WordPress Ajax Action
-        opts.parameters['action'] = 'cloudflare_proxy';
+        opts.parameters['action'] = '<?php echo \CF\WordPress\Hooks::WP_AJAX_ACTION; ?>'
 
         if (opts.method.toUpperCase() === 'GET') {
             var clientAPIURL = '<?php echo \CF\API\Client::ENDPOINT; ?>';

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -16,6 +16,8 @@ class Hooks
     protected $logger;
     protected $proxy;
 
+    const CLOUDFLARE_JSON = "CLOUDFLARE_JSON";
+
     public function __construct()
     {
         $this->config = new Integration\DefaultConfig(file_get_contents(CLOUDFLARE_PLUGIN_DIR.'config.js', true));
@@ -249,5 +251,12 @@ class Hooks
     public function http2ServerPushInit()
     {
         HTTP2ServerPush::init();
+    }
+
+    public function getCloudflareRequestJSON()
+    {
+        if ($_GET['action'] === 'cloudflare_proxy') {
+            $GLOBALS[CLOUDFLARE_JSON] = file_get_contents('php://input');
+        }
     }
 }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -16,7 +16,8 @@ class Hooks
     protected $logger;
     protected $proxy;
 
-    const CLOUDFLARE_JSON = "CLOUDFLARE_JSON";
+    const CLOUDFLARE_JSON = 'CLOUDFLARE_JSON';
+    const WP_AJAX_ACTION = 'cloudflare_proxy';
 
     public function __construct()
     {
@@ -255,7 +256,7 @@ class Hooks
 
     public function getCloudflareRequestJSON()
     {
-        if ($_GET['action'] === 'cloudflare_proxy') {
+        if ($_GET['action'] === WP_AJAX_ACTION) {
             $GLOBALS[CLOUDFLARE_JSON] = file_get_contents('php://input');
         }
     }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -254,6 +254,11 @@ class Hooks
         HTTP2ServerPush::init();
     }
 
+    /*
+     * php://input can only be read once before PHP 5.6, try to grab it ONLY if the request
+     * is coming from the cloudflare proxy.  We store it in a global so \CF\WordPress\Proxy
+     * can act on the request body later on in the script execution. 
+     */
     public function getCloudflareRequestJSON()
     {
         if ($_GET['action'] === WP_AJAX_ACTION) {

--- a/src/WordPress/Proxy.php
+++ b/src/WordPress/Proxy.php
@@ -102,7 +102,7 @@ class Proxy
      */
     public function getJSONBody()
     {
-        return file_get_contents('php://input');
+        return $GLOBALS[Hooks::CLOUDFLARE_JSON];
     }
 
     /**

--- a/src/WordPress/Proxy.php
+++ b/src/WordPress/Proxy.php
@@ -98,6 +98,9 @@ class Proxy
     }
 
     /**
+     * Wrapped in a function so it can be
+     * mocked during testing
+     *
      * @return json
      */
     public function getJSONBody()


### PR DESCRIPTION
`php://input` can only be read once < PHP 5.6 and PUT requests can't be rewound.  This means we need to try to read the `php://input` stream as early in the script execution as possible.  Wordpress outlines the order in which hooks execute [here](https://codex.wordpress.org/Plugin_API/Action_Reference).  The order is:

- `muplugins_loaded`
- `registered_taxonomy`
- `registered_post_type`
- `plugins_loaded`

`muplugins_loaded` is only available in WordPress 4.x, `register_taxonomy` doesn't list the version it was introduced in, `registered_post_type` doesn't have docs which leaves us with `plugins_loaded`.

This bug was surfaced because a plugin was reading Cloudflare requests after hooking into `setup_theme` which executes after `plugins_loaded`.   



