### PR TITLE
Add a filter to modify the list urls purged by wordpress via CloudFlare API

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -59,7 +59,7 @@ $cloudflarePurgeEverythingActions = array(
 );
 
 foreach ($cloudflarePurgeEverythingActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheEverything'));
+    add_action($action, array($cloudflareHooks, 'purgeCacheEverything'), PHP_INT_MAX);
 }
 
 $cloudflarePurgeURLActions = array(
@@ -69,5 +69,5 @@ $cloudflarePurgeURLActions = array(
 );
 
 foreach ($cloudflarePurgeURLActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheByRevelantURLs'), 10, 2);
+    add_action($action, array($cloudflareHooks, 'purgeCacheByRevelantURLs'), PHP_INT_MAX, 2);
 }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -238,7 +238,7 @@ class Hooks
             $listofurls = array_merge($listofurls, str_replace('http://', 'https://', $listofurls));
         }
 
-        return $listofurls;
+        return apply_filters('cf_get_post_related_links', $listofurls, $postId);
     }
 
     protected function isPluginSpecificCacheEnabled()


### PR DESCRIPTION
Adds a filter to the return value of getPostRelatedUrls to inject custom pages to the list of URLs that get purged when a post gets modified.

With this filter a user could hook into the list of urls send to the CF Api and modify them before the get send to the CF API.

We currently use this with the fork in production. Our filter that modifies the list of URLs looks like this:

      <?php
         function adjust_cloudflare_purge_urls($listOfUrls, $postId) {

           $listOfUrls[] = 'http://example.com/custom-entpoint-2-not-related-to-post';
           $listOfUrls[] = 'http://example.com/custom-entpoint-2-not-related-to-post';

           return $listOfUrls;
        }

        add_filter('cf_get_post_related_links', 'adjust_cloudflare_purge_urls', 10, 2);

This PR is related to #192 

