### PR TITLE
Adjust default purge hooks priority

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -59,7 +59,7 @@ $cloudflarePurgeEverythingActions = array(
 );
 
 foreach ($cloudflarePurgeEverythingActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheEverything'));
+    add_action($action, array($cloudflareHooks, 'purgeCacheEverything'), PHP_INT_MAX);
 }
 
 $cloudflarePurgeURLActions = array(
@@ -69,5 +69,5 @@ $cloudflarePurgeURLActions = array(
 );
 
 foreach ($cloudflarePurgeURLActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheByRevelantURLs'), 10, 2);
+    add_action($action, array($cloudflareHooks, 'purgeCacheByRevelantURLs'), PHP_INT_MAX, 2);
 }


### PR DESCRIPTION
Set the default priority for purge hooks to `PHP_INT_MAX` the gives third party plugins the chance to run before CF cache is purged. This should be backwards compatible till PHP 5.0.5.

The reason for this is that if a third party plugin hooking into the same actions like the CF plugin does it could potentially create a race condition.

**For example:**
- plugins that clear NGINX cache
- plugins that generate a static version of a page

Both example could could take some time to finish and have the potential to deliver style cache results if the run on the same or lower priority.