### PR TITLE
Adding  a new filter cloudflare_purge_by_url

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -62,6 +62,23 @@ foreach ($cloudflarePurgeEverythingActions as $action) {
     add_action($action, array($cloudflareHooks, 'purgeCacheEverything'));
 }
 
+/**
+ * You can filter the list of URLs that get purged by Cloudflare after a post is 
+ * modified by implementing a filter for the "cloudflare_purge_by_url" hook.
+ *
+ * @Example:
+ *
+ * /**
+ *  * @param array $urls A list of post related URLs
+ *  * @param integer $post_id the post ID that was modified
+ *  * /
+ * function your_cloudflare_url_filter($urls, $post_id) {
+ *   // modify urls
+ *   return $urls;
+ * }
+ *
+ * add_filter('cloudflare_purge_by_url', your_cloudflare_url_filter, 10, 2);
+ */
 $cloudflarePurgeURLActions = array(
     'deleted_post',                     // Delete a post
     'edit_post',                        // Edit a post - includes leaving comments

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -151,6 +151,7 @@ class Hooks
             }
 
             $urls = $this->getPostRelatedLinks($postId);
+            $urls = apply_filters('cloudflare_purge_by_url', $urls, $postId);
 
             $zoneTag = $this->api->getZoneTag($wpDomain);
 


### PR DESCRIPTION
To modify the list of URLs that eventually get purged by Cloudflare through the wordpress plugin a new filter was introduced. The is related to the earlier PR #194 and has the suggesting made by @thellimist 