### PR TITLE
Feature/cache zone tag selective clear

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -127,10 +127,10 @@ class Hooks
 
     public function purgeCacheByRevelantURLs($postId)
     {
-    	//allow excluding a purge via filter
-	    if( !apply_filters( 'cloudflare/hooks/purge-relevant-urls', true, $postId ) ){
-		    return;
-	    }
+        //allow excluding a purge via filter
+        if (!apply_filters('cloudflare/hooks/purge-relevant-urls', true, $postId)) {
+            return;
+        }
 
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -127,10 +127,10 @@ class Hooks
 
     public function purgeCacheByRevelantURLs($postId)
     {
-        //allow excluding a purge via filter
-        if (!apply_filters('cloudflare/hooks/purge-relevant-urls', true, $postId)) {
-            return;
-        }
+    	//allow excluding a purge via filter
+	    if( apply_filters( 'cloudflare_exclude_purge_by_relevant_url', false, $postId ) ){
+		    return;
+	    }
 
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -127,10 +127,10 @@ class Hooks
 
     public function purgeCacheByRevelantURLs($postId)
     {
-    	//allow excluding a purge via filter
-	    if( apply_filters( 'cloudflare_exclude_purge_by_relevant_url', false, $postId ) ){
-		    return;
-	    }
+        //allow excluding a purge via filter
+        if (apply_filters('cloudflare_exclude_purge_by_relevant_url', false, $postId)) {
+            return;
+        }
 
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -127,6 +127,11 @@ class Hooks
 
     public function purgeCacheByRevelantURLs($postId)
     {
+    	//allow excluding a purge via filter
+	    if( !apply_filters( 'cloudflare/hooks/purge-relevant-urls', true, $postId ) ){
+		    return;
+	    }
+
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -14,6 +14,11 @@ class WordPressClientAPI extends Client
      */
     public function getZoneTag($zone_name)
     {
+	    $zone_tag = wp_cache_get( 'cloudflare/client-api/zone-tag' );
+	    if( false !== $zone_tag ){
+		    return $zone_tag;
+	    }
+
         $request = new Request('GET', 'zones/', array('name' => $zone_name), array());
         $response = $this->callAPI($request);
 
@@ -26,6 +31,8 @@ class WordPressClientAPI extends Client
                 }
             }
         }
+
+	    wp_cache_set( 'cloudflare/client-api/zone-tag', $zone_tag );
 
         return $zone_tag;
     }

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -14,10 +14,10 @@ class WordPressClientAPI extends Client
      */
     public function getZoneTag($zone_name)
     {
-	    $zone_tag = wp_cache_get( 'cloudflare/client-api/zone-tag' );
-	    if( false !== $zone_tag ){
-		    return $zone_tag;
-	    }
+        $zone_tag = wp_cache_get('cloudflare/client-api/zone-tag');
+        if (false !== $zone_tag) {
+            return $zone_tag;
+        }
 
         $request = new Request('GET', 'zones/', array('name' => $zone_name), array());
         $response = $this->callAPI($request);
@@ -32,7 +32,7 @@ class WordPressClientAPI extends Client
             }
         }
 
-	    wp_cache_set( 'cloudflare/client-api/zone-tag', $zone_tag );
+        wp_cache_set('cloudflare/client-api/zone-tag', $zone_tag);
 
         return $zone_tag;
     }


### PR DESCRIPTION
1. Caches the Zone-tag in WP object cache to allow reuses in the tag instead of and additional request on each purge. Most useful in environments with an external object cache and scripts that run high quantity imports. 
2. Allow selectively excluding a purge cache request via a filter.  Also useful to reduce the number of requests when not needed. 

The inspiration for this came out of an issue where a site was hitting the Cloudflare rate limit when importing an ical feed. 