### PR TITLE
Disable HTTP/2 Push on wp-admin pages, fixes #204

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -30,7 +30,7 @@ $cloudflareHooks = new \CF\WordPress\Hooks();
 add_action('plugins_loaded', array($cloudflareHooks, 'getCloudflareRequestJSON'));
 
 // Enable HTTP2 Server Push
-if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE) {
+if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE && !is_admin()) {
     add_action('init', array($cloudflareHooks, 'http2ServerPushInit'));
 }
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/Cloudflare-WordPress/issues/204 issue, where HTTP/2 Push produce too big headers causing Cloudflare 502 Bad Gateway error while on WordPress Admin Panel pages. 

[`is_admin()`](https://codex.wordpress.org/Function_Reference/is_admin) returns true for admin pages and is clean solution. 