### PR TITLE
Use empty() instead of count

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -130,7 +130,7 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) <= 0) {
+            if (empty($wpDomain)) {
                 return;
             }
 


### PR DESCRIPTION
Quick fix to correct PHP 7.2 warning when using count() on a non-countable type.  The issue has been described in #210 by several other users.  PHP 7.2 change details can be found [here](https://secure.php.net/manual/en/migration72.incompatible.php).

@thellimist 