### PR TITLE
FIX: 'Warning:  count(): Parameter must be an array or an object that…

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -111,8 +111,8 @@ class Hooks
     {
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
-            $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) > 0) {
+            if (count($wpDomainList) > 0) {
+                $wpDomain = $wpDomainList[0];
                 $zoneTag = $this->api->getZoneTag($wpDomain);
 
                 if (isset($zoneTag)) {
@@ -129,11 +129,11 @@ class Hooks
     {
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
-            $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) <= 0) {
+            if (count($wpDomainList) <= 0) {
                 return;
             }
 
+            $wpDomain = $wpDomainList[0];
             $validPostStatus = array('publish', 'trash');
             $thisPostStatus = get_post_status($postId);
 


### PR DESCRIPTION
@thellimist 
Fix: Moves the count which is being used on a string to the array.