### PR TITLE
FIX: count() warning by counting $wpDomainList array instead of $wpDomain integer

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -130,7 +130,7 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) <= 0) {
+            if (count($wpDomainList) <= 0) {
                 return;
             }
 


### PR DESCRIPTION
Fix for #210 

I'm pretty sure the count() warning stems from the fact that the count() function is used to count arrays and NOT integers. But in Hooks.php, it is actually trying to count an integer, here's why.

On line 133 from Hooks.php where the warning is triggered, you have the following line of code:
```
if (count($wpDomain) <= 0) {
```
$wpDomain is actually NOT an array and is declared as a value from an array on line 132:
```
$wpDomain = $wpDomainList[0];
```
Replacing line 133 with the following code fixes the count() warning:
```
if (count($wpDomainList) <= 0) {
```