### PR TITLE
Replace count() with strlen()

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -130,7 +130,7 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) <= 0) {
+            if (strlen($wpDomain) <= 0) {
                 return;
             }
 


### PR DESCRIPTION
Fix warning in PHP 7.2+ caused by using count() on a string.