### PR TITLE
Added type checking to Hooks.php

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -112,7 +112,8 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if ((is_array($wpDomain) || is_object($wpDomain)) && count($wpDomain) > 0) {
+
+            if (((is_array($wpDomain) || is_object($wpDomain)) && count($wpDomain) > 0) || (is_string($wpDomain) && $wpDomain !== '')) {
                 $zoneTag = $this->api->getZoneTag($wpDomain);
 
                 if (isset($zoneTag)) {
@@ -130,7 +131,8 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if ((is_array($wpDomain) || is_object($wpDomain)) && count($wpDomain) <= 0) {
+
+            if (((is_array($wpDomain) || is_object($wpDomain)) && count($wpDomain) <= 0)  || (is_string($wpDomain) && $wpDomain !== '')) {
                 return;
             }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -112,7 +112,7 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) > 0) {
+            if ((is_array($wpDomain) || is_object($wpDomain)) && count($wpDomain) > 0) {
                 $zoneTag = $this->api->getZoneTag($wpDomain);
 
                 if (isset($zoneTag)) {
@@ -130,7 +130,7 @@ class Hooks
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
             $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) <= 0) {
+            if ((is_array($wpDomain) || is_object($wpDomain)) && count($wpDomain) <= 0) {
                 return;
             }
 


### PR DESCRIPTION
@manatarms
Fixes #210
Fixes #224
Fixes #223

Added type checking to Hooks.php for functions purgeCacheEverything and purgeCacheByRelevantURLs

This is in regards to warning
`count(): Parameter must be an array or an object that implements Countable wp-content/plugins/cloudflare/src/WordPress/Hooks.php on line 133`
mentioned here: [count(): Parameter must be an array in Hooks.php on line 133](https://wordpress.org/support/topic/count-parameter-must-be-an-array-in-hooks-php-on-line-133/)

We check if $wpDomain is an array or object before running count. If count is not implemented, PHP should generate a warning normally.