### PR TITLE
Turn on IPv6 by default

### DIFF
--- a/src/WordPress/PluginActions.php
+++ b/src/WordPress/PluginActions.php
@@ -79,7 +79,7 @@ class PluginActions extends AbstractPluginActions
             throw new ZoneSettingFailException();
         }
 
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'ipv6', array('value' => 'off'));
+        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'ipv6', array('value' => 'on'));
         if (!$result) {
             throw new ZoneSettingFailException();
         }


### PR DESCRIPTION
WordPress works fine over IPv6, so update the default setting to reflect that.