### PR TITLE
PI-1272 Fix countable error in PHP 7.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,32 +3,32 @@
         "psr-4": {
             "CF\\": "src/"
         }
-    }, 
-    "description": "A Cloudflare plugin for WordPress", 
-    "license": "BSD-3-Clause", 
-    "name": "cloudflare/wordpress-plugin", 
+    },
+    "description": "A Cloudflare plugin for WordPress",
+    "license": "BSD-3-Clause",
+    "name": "cloudflare/wordpress-plugin",
     "require": {
-        "cloudflare/cf-ip-rewrite": "^1.0.0", 
-        "cloudflare/cloudflare-plugin-backend": "^1.1", 
+        "cloudflare/cf-ip-rewrite": "^1.0.0",
+        "cloudflare/cloudflare-plugin-backend": "^1.1",
         "symfony/yaml": "~2.6"
-    }, 
+    },
     "require-dev": {
-        "johnkary/phpunit-speedtrap": "1.0.1", 
-        "php-mock/php-mock-phpunit": "^1.1", 
-        "phpunit/phpunit": "4.8.*", 
-        "squizlabs/php_codesniffer": "2.*", 
-        "wimg/php-compatibility": "*", 
+        "johnkary/phpunit-speedtrap": "1.0.1",
+        "php-mock/php-mock-phpunit": "^1.1",
+        "phpunit/phpunit": "4.8.*",
+        "squizlabs/php_codesniffer": "2.*",
+        "wimg/php-compatibility": "*",
         "simplyadmire/composer-plugins": "@dev"
-    }, 
+    },
     "scripts": {
-        "format": "php vendor/squizlabs/php_codesniffer/scripts/phpcs -n --standard=phpcs.xml", 
-        "test": "php vendor/phpunit/phpunit/phpunit", 
-        "post-install-cmd": "@php-compatibility-install", 
-        "post-update-cmd": "@php-compatibility-install", 
+        "format": "php vendor/squizlabs/php_codesniffer/scripts/phpcs -d date.timezone=UTC -n --standard=phpcs.xml",
+        "test": "php vendor/phpunit/phpunit/phpunit",
+        "post-install-cmd": "@php-compatibility-install",
+        "post-update-cmd": "@php-compatibility-install",
         "php-compatibility-install": "rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility"
-    }, 
+    },
     "_comment": [
         "php-compatibility-install comes from https://github.com/wimg/PHPCompatibility/issues/102#issuecomment-255778195"
-    ], 
+    ],
     "version": "3.3.2"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset name="Cloudflare_WordPress_PSR2">
     <file>src/</file>
 
-    <config name="testVersion" value="5.3-5.4"/>
+    <config name="testVersion" value="5.3-7.3"/>
     <rule ref="PHPCompatibility"/>
 
     <rule ref="PSR2"/>

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -111,8 +111,9 @@ class Hooks
     {
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
-            $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) > 0) {
+            if (count($wpDomainList) > 0) {
+                $wpDomain = $wpDomainList[0];
+
                 $zoneTag = $this->api->getZoneTag($wpDomain);
 
                 if (isset($zoneTag)) {
@@ -129,10 +130,10 @@ class Hooks
     {
         if ($this->isPluginSpecificCacheEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
-            $wpDomain = $wpDomainList[0];
-            if (count($wpDomain) <= 0) {
+            if (count($wpDomainList) <= 0) {
                 return;
             }
+            $wpDomain = $wpDomainList[0];
 
             $validPostStatus = array('publish', 'trash');
             $thisPostStatus = get_post_status($postId);

--- a/src/WordPress/WordPressAPI.php
+++ b/src/WordPress/WordPressAPI.php
@@ -90,7 +90,7 @@ class WordPressAPI implements IntegrationAPIInterface
     {
         $cachedDomainName = $this->dataStore->getDomainNameCache();
         if (empty($cachedDomainName)) {
-            return [];
+            return array();
         }
 
         return array($cachedDomainName);

--- a/src/WordPress/WordPressAPI.php
+++ b/src/WordPress/WordPressAPI.php
@@ -84,13 +84,13 @@ class WordPressAPI implements IntegrationAPIInterface
      *
      * @param null $userId
      *
-     * @return mixed
+     * @return array
      */
     public function getDomainList($userId = null)
     {
         $cachedDomainName = $this->dataStore->getDomainNameCache();
         if (empty($cachedDomainName)) {
-            return;
+            return [];
         }
 
         return array($cachedDomainName);


### PR DESCRIPTION
Fixes errors related to attempts to treat string $wpDomain as countable type. This should also address errors relating to headers already being sent due to the Warnings output by PHP when encountering the mismatched type: 

```
$ vendor/bin/phpunit

PHPUnit 4.8.35 by Sebastian Bergmann and contributors.

..........................................

Time: 104 ms, Memory: 6.00MB

OK (42 tests, 115 assertions)

```