### PR TITLE
Fix HTTP/2 server push breaking Autoptimize plugin

### DIFF
--- a/src/WordPress/HTTP2ServerPush.php
+++ b/src/WordPress/HTTP2ServerPush.php
@@ -23,12 +23,22 @@ class HTTP2ServerPush
     {
         self::$initiated = true;
 
+        $autoptimize_js_enabled = (get_option('autoptimize_js') && get_option('autoptimize_js') === 'on');
+        $autoptimize_css_enabled = (get_option('autoptimize_css') && get_option('autoptimize_css') === 'on');
+
         add_action('wp_head', array('\CF\WordPress\HTTP2ServerPush', 'http2ResourceHints'), 99, 1);
 
-        // If Autoptimize exists, register for its filter, which emits minified and optimized assets
+        // If Autoptimize exists, prefer the optimized assets it emits over usual WordPress enqueued scripts
         if (class_exists('autoptimizeMain')) {
             add_filter('autoptimize_filter_cache_getname', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
+            if (!$autoptimize_js_enabled) {
+                add_filter('script_loader_src', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
+            }
+            if (!$autoptimize_css_enabled) {
+                add_filter('style_loader_src', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
+            }
         } else {
+            // Autoptimize plugin is not activated, so fallback to the usual WordPress script and style queues
             add_filter('script_loader_src', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
             add_filter('style_loader_src', array('\CF\WordPress\HTTP2ServerPush', 'http2LinkPreloadHeader'), 99, 1);
         }


### PR DESCRIPTION
These changes fix a compatibility issue with the Cloudflare plugin's HTTP/2 server push feature and the Autoptimize plugin's script and stylesheet concatenation and minification feature. 

```
$ composer format && composer test
> php vendor/squizlabs/php_codesniffer/scripts/phpcs -d date.timezone=UTC -n --standard=phpcs.xml
> php vendor/phpunit/phpunit/phpunit

PHPUnit 4.8.35 by Sebastian Bergmann and contributors.

..........................................

Time: 106 ms, Memory: 6.00MB

OK (42 tests, 115 assertions)
```