### PR TITLE
Fix modify header exception thrown during wp-cron (Fixes #305, #302)

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -307,11 +307,15 @@ class Hooks
 
     public function initAutomaticPlatformOptimization()
     {
-      // add header unconditionally so we can detect plugin is activated
-      if (!is_user_logged_in() ) {
-        header( 'cf-edge-cache: cache,platform=wordpress' );
-      } else {
-        header( 'cf-edge-cache: no-cache' );
-      }
+        if (wp_doing_cron()) {
+            return;
+        }
+
+        // add header unconditionally so we can detect plugin is activated
+        if (!is_user_logged_in()) {
+            header('cf-edge-cache: cache,platform=wordpress');
+        } else {
+            header('cf-edge-cache: no-cache');
+        }
     }
 }


### PR DESCRIPTION
- fix(hooks): Add a condition check for cron before initializing APO (Fixes #305, Fixes #302)
- chore(hooks): Fix indent spacing