### PR TITLE
check if headers have been sent before setting cf-edge-cache

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -307,6 +307,12 @@ class Hooks
 
     public function initAutomaticPlatformOptimization()
     {
+      // it could be too late to set the headers,
+      // return early without triggering a warning in logs
+      if (headers_sent()) {
+        return;
+      }
+
       // add header unconditionally so we can detect plugin is activated
       if (!is_user_logged_in() ) {
         header( 'cf-edge-cache: cache,platform=wordpress' );


### PR DESCRIPTION
Don't set cf-edge-header if headers already sent. (Fixes #305, Fixes #302)