### PR TITLE
Release v3.8.7

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -3,7 +3,7 @@
 Plugin Name: Cloudflare
 Plugin URI: https://blog.cloudflare.com/new-wordpress-plugin/
 Description: Cloudflare speeds up and protects your WordPress site.
-Version: 3.8.6
+Version: 3.8.7
 Author: Cloudflare, Inc.
 License: BSD-3-Clause
 */

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "_comment": [
         "php-compatibility-install comes from https://github.com/wimg/PHPCompatibility/issues/102#issuecomment-255778195"
     ],
-    "version": "3.8.6",
+    "version": "3.8.7",
     "config": {
         "platform": {
             "php": "5.6.40"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0379287357b381b91ae3676bfb786ab4",
+    "content-hash": "f44c2e734a8d27e1bcdf9e040595340d",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",
@@ -1306,23 +1306,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1347,7 +1347,13 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",

--- a/config.json
+++ b/config.json
@@ -25,5 +25,5 @@
     },
     "locale": "en",
     "integrationName": "wordpress",
-    "version": "3.8.6"
+    "version": "3.8.7"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: icyapril, manatarms, thillcf, deuill, epatryk
 Tags: cloudflare, seo, ssl, ddos, speed, security, cdn, performance, free
 Requires at least: 3.4
 Tested up to: 5.5.1
-Stable tag: 3.8.6
+Stable tag: 3.8.7
 License: BSD-3-Clause
 
 All of Cloudflare’s performance and security benefits in a simple one-click install.
@@ -88,6 +88,12 @@ Yes, Cloudflare works with, and helps speed up your site even more, if you have 
 == Screenshots ==
 
 == Changelog ==
+
+= 3.8.7 - 2020-12-07 =
+
+* Purge taxonomy feed URLs
+* Fix changing APO settings (cf, wordpress, plugin) when running on subdomain
+* Fix setting hostname override
 
 = 3.8.6 - 2020-11-19 =
 

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1215,26 +1215,26 @@
     },
     {
         "name": "sebastian/code-unit-reverse-lookup",
-        "version": "1.0.1",
-        "version_normalized": "1.0.1.0",
+        "version": "1.0.2",
+        "version_normalized": "1.0.2.0",
         "source": {
             "type": "git",
             "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-            "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-            "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+            "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+            "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
             "shasum": ""
         },
         "require": {
-            "php": "^5.6 || ^7.0"
+            "php": ">=5.6"
         },
         "require-dev": {
-            "phpunit/phpunit": "^5.7 || ^6.0"
+            "phpunit/phpunit": "^8.5"
         },
-        "time": "2017-03-04T06:30:41+00:00",
+        "time": "2020-11-30T08:15:22+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -1258,7 +1258,13 @@
             }
         ],
         "description": "Looks up which function or method a line of code belongs to",
-        "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/"
+        "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+        "funding": [
+            {
+                "url": "https://github.com/sebastianbergmann",
+                "type": "github"
+            }
+        ]
     },
     {
         "name": "sebastian/comparator",

--- a/vendor/sebastian/code-unit-reverse-lookup/ChangeLog.md
+++ b/vendor/sebastian/code-unit-reverse-lookup/ChangeLog.md
@@ -2,9 +2,14 @@
 
 All notable changes to `sebastianbergmann/code-unit-reverse-lookup` are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 1.0.0 - 2016-02-13
+## [1.0.2] - 2020-11-30
 
-### Added
+### Changed
+
+* Changed PHP version constraint in `composer.json` from `^5.6 || ^7.0` to `>=5.6`
+
+## 1.0.0 - 2016-02-13
 
 * Initial release
 
+[1.0.2]: https://github.com/sebastianbergmann/code-unit-reverse-lookup/compare/1.0.1...1.0.2

--- a/vendor/sebastian/code-unit-reverse-lookup/composer.json
+++ b/vendor/sebastian/code-unit-reverse-lookup/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "classmap": [

--- a/vendor/sebastian/code-unit-reverse-lookup/tests/WizardTest.php
+++ b/vendor/sebastian/code-unit-reverse-lookup/tests/WizardTest.php
@@ -22,7 +22,7 @@ class WizardTest extends TestCase
      */
     private $wizard;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->wizard = new Wizard;
     }


### PR DESCRIPTION
= 3.8.7 - 2020-12-07 =

* Purge taxonomy feed URLs
* Fix changing APO settings (cf, wordpress, plugin) when running on subdomain
* Fix setting hostname override