### PR TITLE
Purge posts that go from public to private.

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -103,5 +103,5 @@ $cloudflarePurgeURLActions = array(
 $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $cloudflarePurgeURLActions);
 
 foreach ($cloudflarePurgeURLActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX, 2);
+    add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX, 4);
 }


### PR DESCRIPTION
Currently if a post was published publicly and then gets set to private, no cache purge is done, even though that's exactly what you would expect to happen in that case. This is because the hook returns early unless the post is "publish" or "trash" status. I changed it so that if a post is private but it was not private previously (i.e. when the private status is being applied), it still executes the purge.

* Add ...$args to the hook to avoid doing additional queries. This could
likely be used elsewhere in the function instead of querying those
things.
* Make "private" also a "valid" post status, add extra check to still
skip purge unless it's a status change.