### PR TITLE
Purge pagination

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -101,7 +101,7 @@ $cloudflarePurgeURLActions = array(
 $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $cloudflarePurgeURLActions);
 
 foreach ($cloudflarePurgeURLActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX, 2);
+    add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX, 4);
 }
 
 /**

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -256,6 +256,20 @@ class Hooks
             array_push($listofurls, $pageLink);
         }
 
+        // Refresh pagination
+        $total_posts_count = wp_count_posts()->publish;
+        $posts_per_page = get_option('posts_per_page');
+        // Limit to up to 3 pages
+        $page_number_max = min(3, ceil($total_posts_count / $posts_per_page));
+
+        $this->logger->debug("total_posts_count $total_posts_count");
+        $this->logger->debug("posts_per_page  $posts_per_page");
+        $this->logger->debug("page_number_max $page_number_max");
+
+        foreach (range(1, $page_number_max) as $page_number) {
+            array_push($listofurls, home_url(sprintf('/page/%s/', $page_number)));
+        }
+
         // Attachments
         if ('attachment' == $postType) {
             $attachmentUrls = array();


### PR DESCRIPTION
Second try to fix https://github.com/cloudflare/Cloudflare-WordPress/issues/337. In addition to previous https://github.com/cloudflare/Cloudflare-WordPress/pull/339/files I limit the number of pages to 3.
Also APO applies Edge Cache TTL of 30 mins for all `example.com/page/*` paginated urls.