### PR TITLE
Purge a post when clean_post_cache is fired on it

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -96,6 +96,7 @@ $cloudflarePurgeURLActions = array(
     'deleted_post',                     // Delete a post
     'delete_attachment',                // Delete an attachment - includes re-uploading
     'post_updated',                     // Update a post
+    'clean_post_cache',                 // Clean a post from the WordPress object cache
 );
 
 $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $cloudflarePurgeURLActions);


### PR DESCRIPTION
fixes #395

If you think this is too aggressive, then another solution would be to listen on `transition_post_status` and purge whenever a post transitions to or from `publish` (including publish-to-publish).