### PR TITLE
Purge a post from APO when its status transitions to or from "publish"

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -100,7 +100,7 @@ $cloudflarePurgeURLActions = array(
 $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $cloudflarePurgeURLActions);
 
 foreach ($cloudflarePurgeURLActions as $action) {
-    add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX, 4);
+    add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX);
 }
 
 /**

--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -95,7 +95,6 @@ foreach ($cloudflarePurgeEverythingActions as $action) {
 $cloudflarePurgeURLActions = array(
     'deleted_post',                     // Delete a post
     'delete_attachment',                // Delete an attachment - includes re-uploading
-    'post_updated',                     // Update a post
 );
 
 $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $cloudflarePurgeURLActions);
@@ -103,6 +102,11 @@ $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $clou
 foreach ($cloudflarePurgeURLActions as $action) {
     add_action($action, array($cloudflareHooks, 'purgeCacheByRelevantURLs'), PHP_INT_MAX, 4);
 }
+
+/**
+ * Register action to account for post status changes
+ */
+add_action('transition_post_status', array($cloudflareHooks, 'purgeCacheOnPostStatusChange'), PHP_INT_MAX, 3);
 
 /**
  * Register two new actions which account for comment status before purging cache

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -126,7 +126,7 @@ class Hooks
         }
     }
 
-    public function purgeCacheByRelevantURLs($postId, ...$args)
+    public function purgeCacheByRelevantURLs($postId)
     {
         if ($this->isPluginSpecificCacheEnabled() || $this->isAutomaticPlatformOptimizationEnabled()) {
             $wpDomainList = $this->integrationAPI->getDomainList();
@@ -135,36 +135,13 @@ class Hooks
             }
             $wpDomain = $wpDomainList[0];
 
-            $validPostStatus = array('publish', 'trash', 'private');
-            $thisPostStatus = get_post_status($postId);
-
-            if (get_permalink($postId) != true || !in_array($thisPostStatus, $validPostStatus)) {
-                return;
-            }
-
-            // We don't need to purge for private posts, except when they were just transitioned from public.
-            if ('private' === $thisPostStatus) {
-                // The action that fires on transition of status is "post_updated", which will have the old version
-                // in the extra args. If that arg is not there we can bail out.
-                if (! isset($args[1])) {
-                    return;
-                }
-                /**
-                 * @var \WP_Post $before Previous version of post.
-                 */
-                list(, $before) = $args;
-
-                if ('private' === $before->post_status) {
-                    return;
-                }
-            }
-
-            if (is_int(wp_is_post_autosave($postId)) ||  is_int(wp_is_post_revision($postId))) {
+            // Do not purge for autosaves or updates to post revisions.
+            if (wp_is_post_autosave($postId) || wp_is_post_revision($postId)) {
                 return;
             }
 
             $savedPost = get_post($postId);
-            if (is_a($savedPost, 'WP_Post') == false) {
+            if (!is_a($savedPost, 'WP_Post')) {
                 return;
             }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -354,6 +354,13 @@ class Hooks
         }
     }
 
+    public function purgeCacheOnPostStatusChange($new_status, $old_status, $post)
+    {
+        if ('publish' === $new_status || 'publish' === $old_status) {
+            $this->purgeCacheByRelevantURLs($post->ID);
+        }
+    }
+
     public function purgeCacheOnCommentStatusChange($new_status, $old_status, $comment)
     {
         if (!isset($comment->comment_post_ID) || empty($comment->comment_post_ID)) {


### PR DESCRIPTION
This includes publish => publish transitions (editing a published post), manually publishing a post, unpublishing a post, or WordPress automatically publishing a scheduled post at the appropriate time.

I removed the `post_updated` hook because it would be redundant, and the current architecture of the plugin would result in multiple purge requests being sent for the same post update.

see #396 (different approach)
fixes #395