### PR TITLE
Document unintuitive WP hook behavior

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -105,6 +105,10 @@ foreach ($cloudflarePurgeURLActions as $action) {
 
 /**
  * Register action to account for post status changes
+ * This includes
+ * - publish => publish transitions (editing a published post: no actual status change but the hook runs nevertheless)
+ * - manually publishing/unpublishing a post
+ * - WordPress automatically publishing a scheduled post at the appropriate time
  */
 add_action('transition_post_status', array($cloudflareHooks, 'purgeCacheOnPostStatusChange'), PHP_INT_MAX, 3);
 


### PR DESCRIPTION
* The `transition_post_status` hook is actually misnamed, since it also
runs when the status doesn't change but the post is edited. This plugin
relies on this behavior to purge published posts on changes. I copied
and slightly authored the documentation for this that was only present
in [the PR description](https://github.com/cloudflare/Cloudflare-WordPress/pull/397#issue-597536270).