### PR TITLE
Small fix on the list of urls to clear the cache

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -174,7 +174,7 @@ class Hooks
         $postTypeTaxonomies = get_object_taxonomies($postType);
 
         foreach ($postTypeTaxonomies as $taxonomy) {
-            //Only if taxonomy is public
+            // Only if taxonomy is public
             $taxonomy_data = get_taxonomy($taxonomy);
             if ($taxonomy_data instanceof WP_Taxonomy && false === $taxonomy_data->public) {
                 continue;

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -5,6 +5,7 @@ namespace CF\WordPress;
 use CF\API\APIInterface;
 use CF\Integration;
 use Psr\Log\LoggerInterface;
+use WP_Taxonomy;
 
 class Hooks
 {
@@ -173,6 +174,12 @@ class Hooks
         $postTypeTaxonomies = get_object_taxonomies($postType);
 
         foreach ($postTypeTaxonomies as $taxonomy) {
+            //Only if taxonomy is public
+            $taxonomy_data = get_taxonomy($taxonomy);
+            if ($taxonomy_data instanceof WP_Taxonomy && false === $taxonomy_data->public) {
+                continue;
+            }
+
             $terms = get_the_terms($postId, $taxonomy);
 
             if (empty($terms) || is_wp_error($terms)) {

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -274,6 +274,9 @@ class Hooks
             $listofurls = array_merge($listofurls, str_replace('http://', 'https://', $listofurls));
         }
 
+        // Clean array if row empty
+        $listofurls = array_filter($listofurls);
+
         return $listofurls;
     }
 


### PR DESCRIPTION
Hello everyone 👋
by trying to correct the problem mentioned here: #404 
I found 2 small improvements:

### Do not send private taxonomy - 1488f65
I noticed that if the user has a private taxonomy, we still send in the table of urls) delete urls to Cloudflare on not-public taxonomy.
In itself it is not annoying, but in the case of many urls, we limit calls to Cloudflare by being more efficient.

### Check that the table is full - eed1052
Likewise it can happen that by the specific construction of custom taxonomy we refuse the feed urls.
Line [192](https://github.com/cloudflare/Cloudflare-WordPress/blob/64fcc91f53d8599b5ca80b3f4430c9f61d8cdd01/src/WordPress/Hooks.php#L192) empty referral.
I added a small row that will clean up the empty rows in the table.

Thank you