### PR TITLE
Only add attachment URL to purge list if WordPress provides info about it

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -259,7 +259,7 @@ class Hooks
             $attachmentUrls = array();
             foreach (get_intermediate_image_sizes() as $size) {
                 $attachmentSrc = wp_get_attachment_image_src($postId, $size);
-                if ($attachmentSrc) {
+                if (is_array($attachmentSrc) && !empty($attachmentSrc)) {
                     $attachmentUrls[] = $attachmentSrc[0];
                 }
             }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -259,7 +259,9 @@ class Hooks
             $attachmentUrls = array();
             foreach (get_intermediate_image_sizes() as $size) {
                 $attachmentSrc = wp_get_attachment_image_src($postId, $size);
-                $attachmentUrls[] = $attachmentSrc[0];
+                if ($attachmentSrc) {
+                    $attachmentUrls[] = $attachmentSrc[0];
+                }
             }
             $listofurls = array_merge(
                 $listofurls,


### PR DESCRIPTION
`wp_get_attachment_image_src()` can return `false` for a given postId/size combo, in which case we should skip past it.

The lack of this test is causing this:

`Trying to access array offset on value of type bool`

<img width="695" alt="CleanShot 2021-05-19 at 12 32 38@2x" src="https://user-images.githubusercontent.com/353790/118850044-57a97900-b89e-11eb-980c-1a9b6df368ae.png">
