### PR TITLE
Support IDN domain comparison

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -54,7 +54,15 @@ jobs:
       with:
         command: run-script clean-crash-test
         version: 1
-        php_version: 7.4
+        php_version: ${{ matrix.php-versions }}
+
+    - name: Remove PHP 8 symfony/polyfill-intl-idn bootstrap
+      uses: php-actions/composer@v5
+      if: ${{ matrix.php-versions != '8.0' }}
+      with:
+        command: run-script remove-php-8-symfony-polyfill-bootstraps
+        version: 1
+        php_version: ${{ matrix.php-versions }}
 
     - name: PHP syntax check
       run: for f in $(find . -name '*.php'); do php -l $f; RETVAL=$?; if [ $RETVAL -ne 0 ]; then exit $RETVAL; fi; done

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "scripts": {
         "format": "php vendor/bin/phpcs -d date.timezone=UTC --standard=phpcs.xml",
         "test": "php vendor/bin/phpunit",
-        "clean-crash-test": "rm -f vendor/phpunit/php-code-coverage/tests/_files/Crash.php"
+        "clean-crash-test": "rm -f vendor/phpunit/php-code-coverage/tests/_files/Crash.php",
+        "remove-php-8-symfony-polyfill-bootstraps": "rm -f vendor/symfony/polyfill-ctype/bootstrap80.php vendor/symfony/polyfill-intl-idn/bootstrap80.php vendor/symfony/polyfill-intl-normalizer/bootstrap80.php"
     },
     "_comment": [
         "php-compatibility-install comes from https://github.com/wimg/PHPCompatibility/issues/102#issuecomment-255778195"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "phpcompatibility/php-compatibility": "*",
         "simplyadmire/composer-plugins": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
-        "phpdocumentor/reflection-docblock": "*"
+        "phpdocumentor/reflection-docblock": "*",
+        "symfony/polyfill-intl-idn": "*"
     },
     "scripts": {
         "format": "php vendor/bin/phpcs -d date.timezone=UTC --standard=phpcs.xml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8f557df0409b3e0755cf1069d0c0e6c",
+    "content-hash": "233a2c0a234b379492c2cdd66b3825e0",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",
@@ -88,16 +88,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -121,7 +121,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -131,7 +131,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         }
     ],
     "packages-dev": [
@@ -268,16 +268,16 @@
         },
         {
             "name": "johnkary/phpunit-speedtrap",
-            "version": "v3.3.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnkary/phpunit-speedtrap.git",
-                "reference": "9ba81d42676da31366c85d3ff8c10a8352d02030"
+                "reference": "5f9b160eac87e975f1c6ca9faee5125f0616fba3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/9ba81d42676da31366c85d3ff8c10a8352d02030",
-                "reference": "9ba81d42676da31366c85d3ff8c10a8352d02030",
+                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/5f9b160eac87e975f1c6ca9faee5125f0616fba3",
+                "reference": "5f9b160eac87e975f1c6ca9faee5125f0616fba3",
                 "shasum": ""
             },
             "require": {
@@ -312,7 +312,7 @@
                 "profile",
                 "slow"
             ],
-            "time": "2020-12-18T16:20:16+00:00"
+            "time": "2021-05-03T02:37:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2022,16 +2022,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -2069,20 +2069,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -2094,7 +2094,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2145,7 +2145,245 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/WordPress/ClientActions.php
+++ b/src/WordPress/ClientActions.php
@@ -5,6 +5,7 @@ namespace CF\WordPress;
 use CF\API\APIInterface;
 use CF\API\Request;
 use CF\Integration\DefaultIntegration;
+use Symfony\Polyfill\Tests\Intl\Idn;
 
 class ClientActions
 {
@@ -43,7 +44,7 @@ class ClientActions
         // We tried to fetch a zone but it's possible we're using an API token,
         // So try again with a zone name filtered API call
         if (!$this->api->responseOk($response)) {
-            $zoneRequest = new Request('GET', 'zones/', array('name' => $this->wordpressAPI->getOriginalDomain()), array());
+            $zoneRequest = new Request('GET', 'zones/', array('name' => idn_to_ascii($this->wordpressAPI->getOriginalDomain()), array()));
             $zoneResponse = $this->api->callAPI($zoneRequest);
 
             return $zoneResponse;
@@ -68,7 +69,7 @@ class ClientActions
         if ($this->api->responseOk($cfZonesList)) {
             $found = false;
             foreach ($cfZonesList['result'] as $zone) {
-                if ($zone['name'] === $wpDomain) {
+                if (idn_to_ascii($zone['name']) === idn_to_ascii($wpDomain)) {
                     $found = true;
                     array_push($domainList, $zone);
                 }

--- a/src/WordPress/ClientActions.php
+++ b/src/WordPress/ClientActions.php
@@ -44,7 +44,7 @@ class ClientActions
         // We tried to fetch a zone but it's possible we're using an API token,
         // So try again with a zone name filtered API call
         if (!$this->api->responseOk($response)) {
-            $zoneRequest = new Request('GET', 'zones/', array('name' => idn_to_ascii($this->wordpressAPI->getOriginalDomain()), array()));
+            $zoneRequest = new Request('GET', 'zones/', array('name' => idn_to_ascii($this->wordpressAPI->getOriginalDomain(), IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46), array()));
             $zoneResponse = $this->api->callAPI($zoneRequest);
 
             return $zoneResponse;
@@ -69,7 +69,7 @@ class ClientActions
         if ($this->api->responseOk($cfZonesList)) {
             $found = false;
             foreach ($cfZonesList['result'] as $zone) {
-                if (idn_to_ascii($zone['name']) === idn_to_ascii($wpDomain)) {
+                if (idn_to_ascii($zone['name'], IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46) === idn_to_ascii($wpDomain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46)) {
                     $found = true;
                     array_push($domainList, $zone);
                 }

--- a/src/WordPress/DataStore.php
+++ b/src/WordPress/DataStore.php
@@ -5,6 +5,7 @@ namespace CF\WordPress;
 use CF\Integration\DefaultLogger;
 use CF\Integration\DataStoreInterface;
 use CF\API\Plugin;
+use Symfony\Polyfill\Tests\Intl\Idn;
 
 class DataStore implements DataStoreInterface
 {
@@ -88,7 +89,7 @@ class DataStore implements DataStoreInterface
     public function getDomainNameCache()
     {
         if (defined('CLOUDFLARE_DOMAIN_NAME') && CLOUDFLARE_DOMAIN_NAME !== '') {
-            return CLOUDFLARE_DOMAIN_NAME;
+            return idn_to_utf8(CLOUDFLARE_DOMAIN_NAME);
         }
 
         $cachedDomainName = $this->get(self::CACHED_DOMAIN_NAME);

--- a/src/WordPress/DataStore.php
+++ b/src/WordPress/DataStore.php
@@ -89,7 +89,7 @@ class DataStore implements DataStoreInterface
     public function getDomainNameCache()
     {
         if (defined('CLOUDFLARE_DOMAIN_NAME') && CLOUDFLARE_DOMAIN_NAME !== '') {
-            return idn_to_utf8(CLOUDFLARE_DOMAIN_NAME);
+            return idn_to_utf8(CLOUDFLARE_DOMAIN_NAME, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
         }
 
         $cachedDomainName = $this->get(self::CACHED_DOMAIN_NAME);

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -4,6 +4,7 @@ namespace CF\WordPress;
 
 use CF\API\Client;
 use CF\API\Request;
+use Symfony\Polyfill\Tests\Intl\Idn;
 
 class WordPressClientAPI extends Client
 {
@@ -14,6 +15,8 @@ class WordPressClientAPI extends Client
      */
     public function getZoneTag($zone_name)
     {
+        $zone_name = idn_to_ascii($zone_name);
+
         $zone_tag = wp_cache_get('cloudflare/client-api/zone-tag/'.$zone_name);
         if (false !== $zone_tag) {
             return $zone_tag;
@@ -25,7 +28,7 @@ class WordPressClientAPI extends Client
         $zone_tag = null;
         if ($this->responseOk($response)) {
             foreach ($response['result'] as $zone) {
-                if ($zone['name'] === $zone_name) {
+                if (idn_to_ascii($zone['name']) === idn_to_ascii($zone_name)) {
                     $zone_tag = $zone['id'];
                     break;
                 }

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -15,7 +15,7 @@ class WordPressClientAPI extends Client
      */
     public function getZoneTag($zone_name)
     {
-        $zone_name = idn_to_ascii($zone_name);
+        $zone_name = idn_to_ascii($zone_name, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
 
         $zone_tag = wp_cache_get('cloudflare/client-api/zone-tag/'.$zone_name);
         if (false !== $zone_tag) {
@@ -28,7 +28,7 @@ class WordPressClientAPI extends Client
         $zone_tag = null;
         if ($this->responseOk($response)) {
             foreach ($response['result'] as $zone) {
-                if (idn_to_ascii($zone['name']) === idn_to_ascii($zone_name)) {
+                if (idn_to_ascii($zone['name'], IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46) === idn_to_ascii($zone_name, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46)) {
                     $zone_tag = $zone['id'];
                     break;
                 }

--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -24,7 +24,7 @@ class WordPressWrapper
     public function getSiteURL()
     {
         if (defined("CLOUDFLARE_DOMAIN") && CLOUDFLARE_DOMAIN != "") {
-            $site_url = idn_to_ascii(CLOUDFLARE_DOMAIN);
+            $site_url = idn_to_ascii(CLOUDFLARE_DOMAIN, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
         } else {
             $site_url = get_site_url();
         }

--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -2,6 +2,8 @@
 
 namespace CF\WordPress;
 
+use Symfony\Polyfill\Tests\Intl\Idn;
+
 class WordPressWrapper
 {
     public function getOption($key, $default)
@@ -21,7 +23,11 @@ class WordPressWrapper
 
     public function getSiteURL()
     {
-        $site_url = get_site_url();
+        if (defined("CLOUDFLARE_DOMAIN") && CLOUDFLARE_DOMAIN != "") {
+            $site_url = idn_to_ascii(CLOUDFLARE_DOMAIN);
+        } else {
+            $site_url = get_site_url();
+        }
 
         if (function_exists('domain_mapping_siteurl')) {
             $site_url = domain_mapping_siteurl($site_url);


### PR DESCRIPTION
In order to determine the zone identifier, the plugin makes a call to
the Cloudflare API and fetchs all the zones the authorization method has
access to. From there, it compares the API response with the site
domain. Unfortunately, in the process of getting to the comparison the
value isn't always utf8 compatible resulting in a missed lookup even
though the zone is actually found in the API result as a utf8 value.

To rectify this, I've updated the comparisons to always convert to ASCII
before performing the comparison which ensures that if either WordPress
or the Cloudflare API respond with something in UTF8 or ASCII, we will
always find it correctly. I opted for ASCII comparisons (and storage)
here for two main reasons. The first is that not all database storage
systems available to WordPress are configured for UTF8. Attempting to
store and lookup these values may cause hard to debug issues. The second
is that ASCII is machine and human readable for comparisons, UTF8 can
have hidden characters or slight variances which the human eye will
miss.

Instead of relying on php-intl extensions for the IDN comparison, we are
using a symfony polyfill which ensures the best compatibility across
hosting providers.