### PR TITLE
Prepare 4.5.0

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -3,7 +3,7 @@
 Plugin Name: Cloudflare
 Plugin URI: https://blog.cloudflare.com/new-wordpress-plugin/
 Description: Cloudflare speeds up and protects your WordPress site.
-Version: 4.4.0
+Version: 4.5.0
 Requires PHP: 7.2
 Author: Cloudflare, Inc.
 License: BSD-3-Clause
@@ -38,12 +38,12 @@ define('CLOUDFLARE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 // PHP version check has to go here because the below code uses namespaces
 if (version_compare(PHP_VERSION, CLOUDFLARE_MIN_PHP_VERSION, '<')) {
     // We need to load "plugin.php" manually to call "deactivate_plugins"
-    require_once ABSPATH.'wp-admin/includes/plugin.php';
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
     deactivate_plugins(plugin_basename(__FILE__), true);
-    wp_die('<p>The Cloudflare plugin requires a PHP version of at least '.CLOUDFLARE_MIN_PHP_VERSION.'; you have '.PHP_VERSION.'.</p>', 'Plugin Activation Error', array('response' => 200, 'back_link' => true));
+    wp_die('<p>The Cloudflare plugin requires a PHP version of at least ' . CLOUDFLARE_MIN_PHP_VERSION . '; you have ' . PHP_VERSION . '.</p>', 'Plugin Activation Error', array('response' => 200, 'back_link' => true));
 }
 
 // Plugin uses namespaces. To support old PHP version which doesn't support
 // namespaces we load everything in "cloudflare.loader.php"
-require_once CLOUDFLARE_PLUGIN_DIR.'cloudflare.loader.php';
+require_once CLOUDFLARE_PLUGIN_DIR . 'cloudflare.loader.php';

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "_comment": [
         "php-compatibility-install comes from https://github.com/wimg/PHPCompatibility/issues/102#issuecomment-255778195"
     ],
-    "version": "4.4.0",
+    "version": "4.5.0",
     "config": {
         "platform": {
             "php": "7.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e820511e3e0d069fd5c2ed962fdbacbe",
+    "content-hash": "06b0d153d416cf85929ecd0e3b939f54",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",

--- a/config.json
+++ b/config.json
@@ -25,5 +25,5 @@
     },
     "locale": "en",
     "integrationName": "wordpress",
-    "version": "4.4.0"
+    "version": "4.5.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: icyapril, manatarms, thillcf, deuill, epatryk, jacobbednarz
 Tags: cloudflare, seo, ssl, ddos, speed, security, cdn, performance, free
 Requires at least: 3.4
 Tested up to: 5.6
-Stable tag: 4.4.0
+Stable tag: 4.5.0
 Requires PHP: 7.2
 License: BSD-3-Clause
 
@@ -101,6 +101,14 @@ Yes, Cloudflare works with, and helps speed up your site even more, if you have 
 == Screenshots ==
 
 == Changelog ==
+
+= 4.5.0 - 2021-06-02 =
+
+* Document unintuitive `transition_post_status` WP hook behavior
+* Only purge public taxonomies while clearing any empty values from the list
+* Better handling of cases where `wp_get_attachment_image_src` is false and not a usable array
+* Support activation of IDN domains
+* Improve development experience by shipping a Docker Compose file with more tooling and documentation
 
 = 4.4.0 - 2021-03-23 =
 


### PR DESCRIPTION
### Changelog

* Document unintuitive `transition_post_status` WP hook behavior
* Only purge public taxonomies while clearing any empty values from the list
* Better handling of cases where `wp_get_attachment_image_src` is false and not a usable array
* Support activation of IDN domains
* Improve development experience by shipping a Docker Compose file with more tooling and documentation