### PR TITLE
rewrite symfony/polyfill bootstrap80.php contents instead of deleting

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -56,13 +56,12 @@ jobs:
         version: 1
         php_version: ${{ matrix.php-versions }}
 
-    - name: Remove PHP 8 symfony/polyfill-intl-idn bootstrap
-      uses: php-actions/composer@v5
-      if: ${{ matrix.php-versions != '8.0' }}
+    - name: Remove unsupported PHP 8 symfony/polyfill return types
+      uses: jacobtomlinson/gha-find-replace@master
       with:
-        command: run-script remove-php-8-symfony-polyfill-bootstraps
-        version: 1
-        php_version: ${{ matrix.php-versions }}
+        find: ": string\\|false"
+        replace: ""
+        include: "vendor/symfony/polyfill-intl-(idn|normalizer)/bootstrap80\\.php"
 
     - name: PHP syntax check
       run: for f in $(find . -name '*.php'); do php -l $f; RETVAL=$?; if [ $RETVAL -ne 0 ]; then exit $RETVAL; fi; done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,14 @@ jobs:
         dev: no
         version: 1
         php_version: 7.4
-        
-    - name: Remove PHP 8 symfony/polyfill-intl-idn bootstrap
-      uses: php-actions/composer@v5
+
+    - name: Remove unsupported PHP 8 symfony/polyfill return types
+      uses: jacobtomlinson/gha-find-replace@master
       with:
-        command: run-script remove-php-8-symfony-polyfill-bootstraps
-        version: 1
-        php_version: 7.4
-        
+        find: ": string\\|false"
+        replace: ""
+        include: "vendor/symfony/polyfill-intl-(idn|normalizer)/bootstrap80\\.php"
+
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
As a part of our deployment pipeline, we push the compiled plugin to
WordPress's SVN server. Unfortunately, the [SVN precommit hook does not
yet support PHP 8](https://meta.trac.wordpress.org/ticket/3791) (which Symfony's intl/idn polyfill includes).
Despite WordPress only offering PHP 8 support in a [beta](https://make.wordpress.org/core/2020/11/23/wordpress-and-php-8-0/) [capacity](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/),
people are running PHP 8 in production and the 4.5.0 release which
caused some sites unusable.

While this isn't ideal as we are rewriting the vendored package
contents, this does workaround the issue by removing the PHP 8 feature
that is causing the lint failure while still leaving the file in a
usable state.
