### PR TITLE
Move `cloudflare-plugin-backend` into plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
     "type": "wordpress-plugin",
     "require": {
         "cloudflare/cf-ip-rewrite": "^1.0.0",
-        "cloudflare/cloudflare-plugin-backend": "2.6.0",
-        "symfony/polyfill-intl-idn": "*"
+        "symfony/polyfill-intl-idn": "*",
+        "psr/log": "^1.0",
+        "guzzlehttp/guzzle": "~5.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "076dac3b2cf7f0f4d508a9efce3219d9",
+    "content-hash": "d839e5bf33b7e2edf348a29b201bf7ed",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",
@@ -52,42 +52,160 @@
             "time": "2017-10-10T15:44:33+00:00"
         },
         {
-            "name": "cloudflare/cloudflare-plugin-backend",
-            "version": "2.6.0",
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/cloudflare/cloudflare-plugin-backend.git",
-                "reference": "6af901b5969120bf42fb51e68ab822285839ef9c"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cloudflare/cloudflare-plugin-backend/zipball/6af901b5969120bf42fb51e68ab822285839ef9c",
-                "reference": "6af901b5969120bf42fb51e68ab822285839ef9c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b87eda7a7162f95574032da17e9323c9899cb6b2",
+                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2",
                 "shasum": ""
             },
             "require": {
-                "psr/log": "^1.0"
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0",
+                "react/promise": "^2.2"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "~5.0",
-                "phpunit/phpunit": "4.8.*",
-                "squizlabs/php_codesniffer": "2.*"
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "CF\\": "src/"
+                    "GuzzleHttp\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
-            "description": "A PHP backend for Cloudflare plugins.",
-            "support": {
-                "source": "https://github.com/cloudflare/cloudflare-plugin-backend/tree/v2.6.0"
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2019-10-30T09:32:00+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
             },
-            "time": "2021-10-10T23:15:44+00:00"
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "abandoned": true,
+            "time": "2018-07-31T13:22:33+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "abandoned": true,
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "psr/log",
@@ -135,6 +253,52 @@
                 "psr-3"
             ],
             "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2020-05-12T15:16:56+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -611,16 +775,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -663,7 +827,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -999,16 +1163,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -1019,7 +1183,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1047,20 +1212,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
                 "shasum": ""
             },
             "require": {
@@ -1068,7 +1233,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1092,37 +1258,37 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-10-02T14:08:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1155,20 +1321,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.14",
+            "version": "7.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c"
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bb7c9a210c72e4709cdde67f8b7362f672f2225c",
-                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/819f92bba8b001d4363065928088de22f25a3a48",
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48",
                 "shasum": ""
             },
             "require": {
@@ -1177,7 +1343,7 @@
                 "php": ">=7.2",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.1 || ^4.0",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
@@ -1224,20 +1390,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-02T13:39:03+00:00"
+            "time": "2021-07-26T12:20:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/28af674ff175d0768a5a978e6de83f697d4a7f05",
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05",
                 "shasum": ""
             },
             "require": {
@@ -1280,7 +1446,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2021-07-19T06:46:01+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1380,16 +1546,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
@@ -1432,20 +1598,20 @@
                 }
             ],
             "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.15",
+            "version": "8.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef"
+                "reference": "50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
-                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984",
+                "reference": "50a58a60b85947b0bee4c8ecfe0f4bbdcf20e984",
                 "shasum": ""
             },
             "require": {
@@ -1457,12 +1623,12 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.0",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.2",
                 "phpspec/prophecy": "^1.10.3",
                 "phpunit/php-code-coverage": "^7.0.12",
-                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-file-iterator": "^2.0.4",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
                 "sebastian/comparator": "^3.0.2",
@@ -1525,7 +1691,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-17T07:27:54+00:00"
+            "time": "2021-09-25T07:37:20+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2210,16 +2376,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -2257,7 +2423,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2387,16 +2553,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -2429,7 +2595,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/API/APIInterface.php
+++ b/src/API/APIInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace CF\API;
+
+interface APIInterface
+{
+    public function callAPI(Request $request);
+    public function createAPIError($message);
+    public function responseOk($response);
+    public function getEndpoint();
+}

--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace CF\API;
+
+use CF\Integration\IntegrationInterface;
+use CF\API\DefaultHttpClient;
+use CF\API\HttpClientInterface;
+
+abstract class AbstractAPIClient implements APIInterface
+{
+    const CONTENT_TYPE_KEY = 'Content-Type';
+    const APPLICATION_JSON_KEY = 'application/json';
+
+    protected $config;
+    protected $data_store;
+    protected $httpClient;
+    protected $logger;
+    protected $integrationAPI;
+
+    /**
+     * @param IntegrationInterface $integration
+     */
+    public function __construct(IntegrationInterface $integration)
+    {
+        $this->config = $integration->getConfig();
+        $this->data_store = $integration->getDataStore();
+        $this->logger = $integration->getLogger();
+        $this->integrationAPI = $integration->getIntegrationAPI();
+    }
+
+    /**
+     * @return HttpClientInterface $httpClient
+     */
+    public function getHttpClient()
+    {
+        if ($this->httpClient === null) {
+            $this->httpClient = new DefaultHttpClient($this->getEndpoint());
+        }
+
+        return $this->httpClient;
+    }
+    /**
+     * @param HttpClientInterface $httpClient
+     */
+    public function setHttpClient(HttpClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return array|mixed
+     */
+    public function callAPI(Request $request)
+    {
+        try {
+            $request = $this->beforeSend($request);
+
+            $response = $this->sendAndLog($request);
+
+            $response = $this->getPaginatedResults($request, $response);
+
+            return $response;
+        } catch (RequestException $e) {
+            $errorMessage = $this->getErrorMessage($e);
+
+            $this->logAPICall($this->getAPIClientName(), array(
+                'type' => 'request',
+                'method' => $request->getMethod(),
+                'path' => $request->getUrl(),
+                'headers' => $request->getHeaders(),
+                'params' => $request->getParameters(),
+                'body' => $request->getBody(), ), true);
+            $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'code' => $e->getCode(), 'body' => $errorMessage, 'stacktrace' => $e->getTraceAsString()), true);
+
+            return $this->createAPIError($errorMessage);
+        }
+    }
+
+    /**
+     * @param  Request $request
+     * @param  [Array] $response
+     * @return [Array] $paginatedResponse
+     */
+    public function getPaginatedResults(Request $request, $response)
+    {
+        if (strtoupper($request->getMethod()) !== 'GET' || !isset($response['result_info']['total_pages'])) {
+            return $response;
+        }
+
+        $mergedResponse = $response;
+        $currentPage = 2; //$response already contains page 1
+        $totalPages = $response['result_info']['total_pages'];
+
+        while ($totalPages >= $currentPage) {
+            $parameters = $request->getParameters();
+            $parameters['page'] = $currentPage;
+            $request->setParameters($parameters);
+
+            $pagedResponse = $this->sendAndLog($request);
+
+            $mergedResponse['result'] = array_merge($mergedResponse['result'], $pagedResponse['result']);
+            // Notify the frontend that pagination is taken care.
+            $mergedResponse['result_info']['notify'] = 'Backend has taken care of pagination. Ouput is merged in results.';
+            $mergedResponse['result_info']['page'] = -1;
+            $mergedResponse['result_info']['count'] = -1;
+
+            $currentPage++;
+        }
+        return $mergedResponse;
+    }
+
+    /**
+     * @param  Request $request
+     * @return Array $response
+     */
+    public function sendAndLog(Request $request)
+    {
+        $response = $this->getHttpClient()->send($request);
+
+        if (!$this->responseOk($response)) {
+            $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'body' => $response), true);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param  $error
+     *
+     * @return string
+     */
+    public function getErrorMessage($error)
+    {
+        return $error->getMessage();
+    }
+
+    /**
+     * @param string $apiName
+     * @param array  $message
+     * @param bool   $isError
+     */
+    public function logAPICall($apiName, $message, $isError)
+    {
+        $sensitiveHeaderKeys = array(
+            'Authorization',
+            'X-Auth-Email',
+            'X-Auth-Key'
+        );
+
+        $logLevel = 'error';
+        if ($isError === false) {
+            $logLevel = 'debug';
+        }
+        if (!is_string($message)) {
+            foreach ($sensitiveHeaderKeys as $value) {
+                if (!empty($message['headers'][$value])) {
+                    $message['headers'][$value] = 'REDACTED';
+                }
+            }
+
+            $message = print_r($message, true);
+        }
+        $this->logger->$logLevel('['.$apiName.'] '.$message);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function getPath(Request $request)
+    {
+        //substring of everything after the endpoint is the path
+        return substr($request->getUrl(), strpos($request->getUrl(), $this->getEndpoint()) + strlen($this->getEndpoint()));
+    }
+
+    public function shouldRouteRequest(Request $request)
+    {
+        return strpos($request->getUrl(), $this->getEndpoint()) !== false;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    abstract public function beforeSend(Request $request);
+
+    /**
+     * @return mixed
+     */
+    abstract public function getAPIClientName();
+
+    /**
+     * @param $message
+     *
+     * @return array
+     */
+    abstract public function createAPIError($message);
+
+    /**
+     * @return mixed
+     */
+    abstract public function getEndpoint();
+}

--- a/src/API/AbstractPluginActions.php
+++ b/src/API/AbstractPluginActions.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace CF\API;
+
+use CF\Integration\DataStoreInterface;
+use CF\Integration\DefaultIntegration;
+
+abstract class AbstractPluginActions
+{
+    protected $api;
+    protected $config;
+    protected $integrationAPI;
+    protected $dataStore;
+    protected $logger;
+    protected $request;
+    protected $clientAPI;
+
+    /**
+     * @param DefaultIntegration $defaultIntegration
+     * @param APIInterface       $api
+     * @param Request            $request
+     */
+    public function __construct(DefaultIntegration $defaultIntegration, APIInterface $api, Request $request)
+    {
+        $this->api = $api;
+        $this->config = $defaultIntegration->getConfig();
+        $this->integrationAPI = $defaultIntegration->getIntegrationAPI();
+        $this->dataStore = $defaultIntegration->getDataStore();
+        $this->logger = $defaultIntegration->getLogger();
+        $this->request = $request;
+
+        $this->clientAPI = new Client($defaultIntegration);
+    }
+
+    /**
+     * @param APIInterface $api
+     */
+    public function setAPI(APIInterface $api)
+    {
+        $this->api = $api;
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @param APIInterface $clientAPI
+     */
+    public function setClientAPI(APIInterface $clientAPI)
+    {
+        $this->clientAPI = $clientAPI;
+    }
+
+    /**
+     * @param DataStoreInterface $dataStore
+     */
+    public function setDataStore(DataStoreInterface $dataStore)
+    {
+        $this->dataStore = $dataStore;
+    }
+
+    public function setLogger(\Psr\Log\LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * POST /account.
+     *
+     * @return mixed
+     */
+    public function login()
+    {
+        $requestBody = $this->request->getBody();
+        if (empty($requestBody['apiKey'])) {
+            return $this->api->createAPIError("Missing required parameter: 'apiKey'.");
+        }
+        if (empty($requestBody['email'])) {
+            return $this->api->createAPIError("Missing required parameter: 'email'.");
+        }
+
+        $isCreated = $this->dataStore->createUserDataStore($requestBody['apiKey'], $requestBody['email'], null, null);
+        if (!$isCreated) {
+            return $this->api->createAPIError('Unable to save user credentials');
+        }
+
+        $params = array();
+        // Only Wordpress gives us access to the zone name, so check for it here
+        if ($this->integrationAPI instanceof \CF\WordPress\WordPressAPI) {
+            $params =  array('name' => $this->integrationAPI->getOriginalDomain());
+        }
+
+        //Make a test request to see if the API Key, email are valid
+        $testRequest = new Request('GET', 'zones/', $params, array());
+        $testResponse = $this->clientAPI->callAPI($testRequest);
+
+        if (!$this->clientAPI->responseOk($testResponse)) {
+            //remove bad credentials
+            $this->dataStore->createUserDataStore(null, null, null, null);
+
+            return $this->api->createAPIError('Email address or API key invalid.');
+        }
+
+        $response = $this->api->createAPISuccessResponse(array('email' => $requestBody['email']));
+
+        return $response;
+    }
+
+    /**
+     * GET /plugin/:zonedId/settings.
+     *
+     * @return mixed
+     */
+    public function getPluginSettings()
+    {
+        $settingsList = Plugin::getPluginSettingsKeys();
+
+        $formattedSettings = array();
+        foreach ($settingsList as $setting) {
+            $value = $this->dataStore->get($setting);
+            if ($value === null) {
+                //setting hasn't been set yet.
+                $value = $this->api->createPluginSettingObject($setting, null, true, null);
+            }
+            array_push($formattedSettings, $value);
+        }
+
+        $response = $this->api->createAPISuccessResponse(
+            $formattedSettings
+        );
+
+        return $response;
+    }
+
+    /**
+     * For PATCH /plugin/:zonedId/settings/:settingId
+     * @return mixed
+     * @throws \Exception
+     */
+    public function patchPluginSettings()
+    {
+        $path_array = explode('/', $this->request->getUrl());
+        $settingId = $path_array[3];
+
+        $body = $this->request->getBody();
+        $value = $body['value'];
+        $options = $this->dataStore->set($settingId, $this->api->createPluginSettingObject($settingId, $value, true, true));
+
+        if (!isset($options)) {
+            return $this->api->createAPIError('Unable to update plugin settings');
+        }
+
+        if ($settingId === Plugin::SETTING_DEFAULT_SETTINGS) {
+            try {
+                $this->applyDefaultSettings();
+            } catch (\Exception $e) {
+                if ($e instanceof Exception\CloudFlareException) {
+                    return $this->api->createAPIError($e->getMessage());
+                } else {
+                    throw $e;
+                }
+            }
+        }
+
+        $response = $this->api->createAPISuccessResponse($this->dataStore->get($settingId));
+
+        return $response;
+    }
+
+    /**
+     * For GET /userconfig
+     * @return mixed
+     */
+    public function getConfig()
+    {
+        $response = $this->api->createAPISuccessResponse(
+            []
+        );
+
+        return $response;
+    }
+
+
+    /**
+     * Children should implement this method to apply the plugin specific default settings.
+     *
+     * @return mixed
+     */
+    abstract public function applyDefaultSettings();
+}

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace CF\API;
+
+use Guzzle\Http\Exception\BadResponseException;
+use CF\Integration\IntegrationInterface;
+
+class Client extends AbstractAPIClient
+{
+    const CLIENT_API_NAME = 'CLIENT API';
+    const ENDPOINT = 'https://api.cloudflare.com/client/v4/';
+    const X_AUTH_KEY = 'X-Auth-Key';
+    const X_AUTH_EMAIL = 'X-Auth-Email';
+    const AUTHORIZATION = 'Authorization';
+    const AUTH_KEY_LEN = 37;
+
+    /**
+     * @param Request $request
+     *
+     * @return Request
+     */
+    public function beforeSend(Request $request)
+    {
+        $key = $this->data_store->getClientV4APIKey();
+        $headers = array(
+            self::CONTENT_TYPE_KEY => self::APPLICATION_JSON_KEY,
+        );
+
+        // Determine authentication method from key format. Global API keys are
+        // always returned in hexadecimal format, while API Tokens are encoded
+        // using a wider range of characters.
+        if (strlen($key) === self::AUTH_KEY_LEN && preg_match('/^[0-9a-f]+$/', $key)) {
+            $headers[self::X_AUTH_EMAIL] = $this->data_store->getCloudFlareEmail();
+            $headers[self::X_AUTH_KEY] = $key;
+        } else {
+            $headers[self::AUTHORIZATION] = "Bearer {$key}";
+        }
+
+        $request->setHeaders($headers);
+
+        // Remove cfCSRFToken (a custom header) to save bandwidth
+        $body = $request->getBody();
+        unset($body['cfCSRFToken']);
+        $request->setBody($body);
+
+        return $request;
+    }
+
+    /**
+     * @param $message
+     *
+     * @return array
+     */
+    public function createAPIError($message)
+    {
+        $this->logger->error($message);
+
+        return array(
+            'result' => null,
+            'success' => false,
+            'errors' => array(
+                array(
+                    'code' => '',
+                    'message' => $message,
+                ),
+            ),
+            'messages' => array(),
+        );
+    }
+
+    /**
+     * @param error
+     *
+     * @return string
+     */
+    public function getErrorMessage($error)
+    {
+        $jsonResponse = json_decode($error->getResponse()->getBody(), true);
+        $errorMessage = $error->getMessage();
+
+        if (count($jsonResponse['errors']) > 0) {
+            $errorMessage = $jsonResponse['errors'][0]['message'];
+        }
+
+        return $errorMessage;
+    }
+
+    /**
+     * @param $response
+     *
+     * @return bool
+     */
+    public function responseOk($response)
+    {
+        return isset($response['success']) ? $response['success'] : false;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return self::ENDPOINT;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAPIClientName()
+    {
+        return self::CLIENT_API_NAME;
+    }
+
+    /**
+     * GET /zones/:id.
+     *
+     * @param $zone_tag
+     *
+     * @return string
+     */
+    public function zoneGetDetails($zone_tag)
+    {
+        $request = new Request('GET', 'zones/'.$zone_tag, array(), array());
+
+        return $this->callAPI($request);
+    }
+}

--- a/src/API/DefaultHttpClient.php
+++ b/src/API/DefaultHttpClient.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace CF\API;
+
+use CF\API\Request;
+use GuzzleHttp;
+use GuzzleHttp\Exception\RequestException;
+
+class DefaultHttpClient implements HttpClientInterface
+{
+    const CONTENT_TYPE_KEY = 'Content-Type';
+    const APPLICATION_JSON_KEY = 'application/json';
+
+    protected $client;
+
+    /**
+     * @param String $endpoint
+     */
+    public function __construct($endpoint)
+    {
+        $this->client = new GuzzleHttp\Client(['base_url' => $endpoint]);
+    }
+
+    /**
+     * @param  Request $request
+     * @throws RequestException
+     * @return Array $response
+     */
+    public function send(Request $request)
+    {
+        $apiRequest = $this->createGuzzleRequest($request);
+
+        $response = $this->client->send($apiRequest)->json();
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new RequestException('Error decoding client API JSON', $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param  Request $request
+     * @return GuzzleHttp\Message\RequestInterface $request
+     */
+    public function createGuzzleRequest(Request $request)
+    {
+        $bodyType = (($request->getHeaders()[self::CONTENT_TYPE_KEY] === self::APPLICATION_JSON_KEY) ? 'json' : 'body');
+
+        $requestOptions = array(
+            'headers' => $request->getHeaders(),
+            'query' => $request->getParameters(),
+            $bodyType => $request->getBody(),
+        );
+
+        return $this->client->createRequest($request->getMethod(), $request->getUrl(), $requestOptions);
+    }
+
+    /**
+     * @param GuzzleHttpClient $client
+     */
+    public function setClient($client)
+    {
+        $this->client = $client;
+    }
+}

--- a/src/API/Exception/CloudFlareException.php
+++ b/src/API/Exception/CloudFlareException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace CF\API\Exception;
+
+abstract class CloudFlareException extends \Exception
+{
+}

--- a/src/API/Exception/ZoneSettingFailException.php
+++ b/src/API/Exception/ZoneSettingFailException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CF\API\Exception;
+
+class ZoneSettingFailException extends CloudFlareException
+{
+    protected $message = 'Oops, something went wrong, please try again in a few minutes';
+}

--- a/src/API/Host.php
+++ b/src/API/Host.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace CF\API;
+
+class Host extends AbstractAPIClient
+{
+    const CF_INTEGRATION_HEADER = 'CF-Integration';
+    const CF_INTEGRTATION_VERSION_HEADER = 'CF-Integration-Version';
+    const HOST_API_NAME = 'HOST API';
+    //self::ENDPOINT_BASE_URL . self::ENDPOINT_PATH isn't a thing so you have to update it twice if it changes.
+    const ENDPOINT_BASE_URL = 'https://api.cloudflare.com/';
+    const ENDPOINT_PATH = 'host-gw.html';
+    const ENDPOINT = 'https://api.cloudflare.com/host-gw.html';
+
+    /**
+     * @param Request $request
+     *
+     * @return Request
+     */
+    public function beforeSend(Request $request)
+    {
+        //Host API isn't restful so path must always self::ENDPOINT_PATH
+        $request->setUrl(self::ENDPOINT_PATH);
+
+        $headers = array(
+            self::CF_INTEGRATION_HEADER => $this->config->getValue('integrationName'),
+            self::CF_INTEGRTATION_VERSION_HEADER => $this->config->getValue('version'),
+        );
+        $request->setHeaders($headers);
+
+        $body = $request->getBody();
+        $user_key_actions = array('zone_set', 'full_zone_set');
+        if (in_array(strtolower($body['act']), $user_key_actions)) {
+            $body['user_key'] = $this->data_store->getHostAPIUserKey();
+        }
+        $body['host_key'] = $this->integrationAPI->getHostAPIKey();
+        $request->setBody($body);
+
+        return $request;
+    }
+
+    /**
+     * @param $host_api_response
+     *
+     * @return bool
+     */
+    public function responseOk($host_api_response)
+    {
+        return $host_api_response['result'] === 'success';
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function getPath(Request $request)
+    {
+        return $request->getBody()['act'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return self::ENDPOINT;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAPIClientName()
+    {
+        return self::HOST_API_NAME;
+    }
+
+    /**
+     * @param $message
+     *
+     * @return array
+     */
+    public function createAPIError($message)
+    {
+        return array(
+            'request' => array(
+                'act' => '',
+            ),
+            'result' => 'error',
+            'msg' => $message,
+            'err_code' => '',
+        );
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public function shouldRouteRequest(Request $request)
+    {
+        return $request->getUrl() === $this->getEndpoint();
+    }
+}

--- a/src/API/HttpClientInterface.php
+++ b/src/API/HttpClientInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CF\API;
+
+interface HttpClientInterface
+{
+    /**
+     * @param  Request $request
+     * @return Array   $response
+     */
+    public function send(Request $request);
+}

--- a/src/API/Plugin.php
+++ b/src/API/Plugin.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace CF\API;
+
+use CF\Integration\IntegrationInterface;
+
+class Plugin extends Client
+{
+    const PLUGIN_API_NAME = 'PLUGIN API';
+    const ENDPOINT = 'https://partners.cloudflare/plugins/';
+
+    //plugin/:id/settings/:human_readable_id setting names
+    const SETTING_DEFAULT_SETTINGS = 'default_settings';
+    const SETTING_IP_REWRITE = 'ip_rewrite';
+    const SETTING_PROTOCOL_REWRITE = 'protocol_rewrite';
+    const SETTING_PLUGIN_SPECIFIC_CACHE = 'plugin_specific_cache';
+    const SETTING_PLUGIN_SPECIFIC_CACHE_TAG = 'plugin_specific_cache_tag';
+    const SETTING_AUTOMATIC_PLATFORM_OPTIMIZATION = 'automatic_platform_optimization';
+    const SETTING_AUTOMATIC_PLATFORM_OPTIMIZATION_CACHE_BY_DEVICE_TYPE = 'automatic_platform_optimization_cache_by_device_type';
+
+    const SETTING_ID_KEY = 'id';
+    const SETTING_VALUE_KEY = 'value';
+    const SETTING_EDITABLE_KEY = 'editable';
+    const SETTING_MODIFIED_DATE_KEY = 'modified_on';
+
+    public static function getPluginSettingsKeys()
+    {
+        return array(
+            self::SETTING_DEFAULT_SETTINGS,
+            self::SETTING_IP_REWRITE,
+            self::SETTING_PROTOCOL_REWRITE,
+            self::SETTING_PLUGIN_SPECIFIC_CACHE,
+            self::SETTING_PLUGIN_SPECIFIC_CACHE_TAG,
+            self::SETTING_AUTOMATIC_PLATFORM_OPTIMIZATION,
+            self::SETTING_AUTOMATIC_PLATFORM_OPTIMIZATION_CACHE_BY_DEVICE_TYPE,
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return self::ENDPOINT;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAPIClientName()
+    {
+        return self::PLUGIN_API_NAME;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return array|mixed
+     */
+    public function callAPI(Request $request)
+    {
+        return $this->createAPIError('The url: '.$request->getUrl().' is not a valid path.');
+    }
+
+    public function createAPISuccessResponse($result)
+    {
+        return array(
+            'success' => true,
+            'result' => $result,
+            'messages' => array(),
+            'errors' => array(),
+        );
+    }
+
+    /**
+     * @param $pluginSettingKey
+     * @param $value
+     * @param $editable
+     * @param $modified_on
+     *
+     * @return array
+     */
+    public function createPluginSettingObject($pluginSettingKey, $value, $editable, $modified_on)
+    {
+        //allow null for settings that have never been set
+        if ($modified_on !== null) {
+            // Format ISO 8601
+            $modified_on = date('c');
+        }
+
+        return array(
+            self::SETTING_ID_KEY => $pluginSettingKey,
+            self::SETTING_VALUE_KEY => $value,
+            self::SETTING_EDITABLE_KEY => $editable,
+            self::SETTING_MODIFIED_DATE_KEY => $modified_on,
+        );
+    }
+}

--- a/src/API/PluginRoutes.php
+++ b/src/API/PluginRoutes.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace CF\API;
+
+class PluginRoutes
+{
+    public static $routes = array(
+        'account' => array(
+            'class' => 'CF\API\AbstractPluginActions',
+            'methods' => array(
+                'POST' => array(
+                    'function' => 'login',
+                ),
+            ),
+        ),
+
+        'plugin/:id/settings' => array(
+            'class' => 'CF\API\AbstractPluginActions',
+            'methods' => array(
+                'GET' => array(
+                    'function' => 'getPluginSettings',
+                ),
+            ),
+        ),
+
+        'plugin/:id/settings/:human_readable_id' => array(
+            'class' => 'CF\API\AbstractPluginActions',
+            'methods' => array(
+                'PATCH' => array(
+                    'function' => 'patchPluginSettings',
+                ),
+            ),
+        ),
+
+        'config' => array(
+            'class' => 'CF\API\AbstractPluginActions',
+            'methods' => array(
+                'GET' => array(
+                    'function' => 'getConfig',
+                ),
+            ),
+        ),
+    );
+}

--- a/src/API/Request.php
+++ b/src/API/Request.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace CF\API;
+
+class Request
+{
+    private $method;
+    private $url;
+    private $parameters;
+    private $body;
+    private $headers;
+
+    /**
+     * @param $method
+     * @param $url
+     * @param $parameters
+     * @param $body
+     */
+    public function __construct($method, $url, $parameters, $body)
+    {
+        $this->method = strtoupper($method);
+        $this->url = $url;
+        $this->parameters = $parameters;
+        $this->body = $body;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @param mixed $method
+     */
+    public function setMethod($method)
+    {
+        $this->method = strtoupper($method);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param mixed $url
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param mixed $parameters
+     */
+    public function setParameters($parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @param mixed $body
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @param mixed $headers
+     */
+    public function setHeaders($headers)
+    {
+        $this->headers = $headers;
+    }
+}

--- a/src/DNSRecord.php
+++ b/src/DNSRecord.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: johnwineman
+ * Date: 4/18/16
+ * Time: 2:40 PM.
+ */
+
+namespace CF;
+
+class DNSRecord
+{
+    private $content;
+    private $name;
+    private $ttl;
+    private $type;
+
+    public static $DNS_RECORDS_CF_CANNOT_PROXY = array('LOC', 'MX', 'NS', 'SPF', 'TXT', 'SRV', ':RAW', '$TTL', 'SOA');
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param mixed $content
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTtl()
+    {
+        return $this->ttl;
+    }
+
+    /**
+     * @param mixed $ttl
+     */
+    public function setTtl($ttl)
+    {
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param mixed $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Integration/ConfigInterface.php
+++ b/src/Integration/ConfigInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CF\Integration;
+
+interface ConfigInterface
+{
+    /**
+     * @param $key
+     *
+     * @return mixed
+     */
+    public function getValue($key);
+}

--- a/src/Integration/DataStoreInterface.php
+++ b/src/Integration/DataStoreInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace CF\Integration;
+
+interface DataStoreInterface
+{
+    /**
+     * @param $client_api_key
+     * @param $email
+     * @param $unique_id
+     * @param $user_key
+     *
+     * @return mixed
+     */
+    public function createUserDataStore($client_api_key, $email, $unique_id, $user_key);
+
+    /**
+     * @return mixed
+     */
+    public function getHostAPIUserUniqueId();
+
+    /**
+     * @return mixed
+     */
+    public function getClientV4APIKey();
+
+    /**
+     * @return mixed
+     */
+    public function getHostAPIUserKey();
+
+    /**
+     * @return mixed
+     */
+    public function getCloudFlareEmail();
+
+    /**
+     * @param $key
+     *
+     * @return mixed
+     */
+    public function get($key);
+
+    /**
+     * @param $key
+     * @param $value
+     *
+     * @return mixed
+     */
+    public function set($key, $value);
+}

--- a/src/Integration/DefaultConfig.php
+++ b/src/Integration/DefaultConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CF\Integration;
+
+class DefaultConfig implements ConfigInterface
+{
+    private $config;
+
+    /**
+     * @param $config from file_get_contents()
+     */
+    public function __construct($config = "[]")
+    {
+        $this->config = json_decode($config, true);
+    }
+
+    /**
+     * @param $key
+     *
+     * @return value or key or null
+     */
+    public function getValue($key)
+    {
+        $value = null;
+        if (array_key_exists($key, $this->config)) {
+            $value = $this->config[$key];
+        }
+
+        return $value;
+    }
+}

--- a/src/Integration/DefaultIntegration.php
+++ b/src/Integration/DefaultIntegration.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace CF\Integration;
+
+use Psr\Log\LoggerInterface;
+
+class DefaultIntegration implements IntegrationInterface
+{
+    private $config;
+    private $integrationAPI;
+    private $dataStore;
+    private $logger;
+
+    /**
+     * @param ConfigInterface                          $config
+     * @param IntegrationAPIInterface                  $integrationAPI
+     * @param DataStoreInterface                       $dataStore
+     * @param LoggerInterface|\Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(ConfigInterface $config, IntegrationAPIInterface $integrationAPI, DataStoreInterface $dataStore, LoggerInterface $logger)
+    {
+        $this->config = $config;
+        $this->integrationAPI = $integrationAPI;
+        $this->dataStore = $dataStore;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return ConfigInterface
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param ConfigInterface $config
+     */
+    public function setConfig(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return integrationAPI
+     */
+    public function getIntegrationAPI()
+    {
+        return $this->integrationAPI;
+    }
+
+    /**
+     * @param IntegrationAPIInterface $integrationAPI
+     */
+    public function setIntegrationAPI(IntegrationAPIInterface $integrationAPI)
+    {
+        $this->integrationAPI = $integrationAPI;
+    }
+
+    /**
+     * @return DataStore
+     */
+    public function getDataStore()
+    {
+        return $this->dataStore;
+    }
+
+    /**
+     * @param DataStoreInterface $dataStore
+     */
+    public function setDataStore(DataStoreInterface $dataStore)
+    {
+        $this->dataStore = $dataStore;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+}

--- a/src/Integration/DefaultLogger.php
+++ b/src/Integration/DefaultLogger.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CF\Integration;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
+
+class DefaultLogger extends AbstractLogger implements LoggerInterface
+{
+    private $debug;
+
+    const PREFIX = '[Cloudflare]';
+
+    /**
+     * @param bool|false $debug
+     */
+    public function __construct($debug = false)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     */
+    public function log($level, $message, array $context = array())
+    {
+        return error_log(self::PREFIX.' '.strtoupper($level).': '.$message.' '.
+            (!empty($context) ? print_r($context, true) : ''));
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array  $context
+     */
+    public function debug($message, array $context = array())
+    {
+        if ($this->debug) {
+            return $this->log(LogLevel::DEBUG, $message, $context);
+        }
+    }
+}

--- a/src/Integration/IntegrationAPIInterface.php
+++ b/src/Integration/IntegrationAPIInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace CF\Integration;
+
+use CF\DNSRecord;
+
+interface IntegrationAPIInterface
+{
+    /**
+     * @param $domain_name
+     *
+     * @return mixed
+     */
+    public function getDNSRecords($domain_name);
+
+    /**
+     * @param $domain_name
+     * @param DNSRecord $DNSRecord
+     *
+     * @return mixed
+     */
+    public function addDNSRecord($domain_name, DNSRecord $DNSRecord);
+
+    /**
+     * @param $domain_name
+     * @param DNSRecord $DNSRecord
+     *
+     * @return mixed
+     */
+    public function editDNSRecord($domain_name, DNSRecord $DNSRecord);
+
+    /**
+     * @param $domain_name
+     * @param DNSRecord $DNSRecord
+     *
+     * @return mixed
+     */
+    public function removeDNSRecord($domain_name, DNSRecord $DNSRecord);
+
+    /**
+     * @return mixed
+     */
+    public function getHostAPIKey();
+
+    /**
+     * @param null $userId
+     *
+     * @return mixed
+     */
+    public function getDomainList($userId = null);
+
+    /**
+     * @return mixed
+     */
+    public function getUserId();
+}

--- a/src/Integration/IntegrationInterface.php
+++ b/src/Integration/IntegrationInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CF\Integration;
+
+interface IntegrationInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getConfig();
+
+    /**
+     * @return mixed
+     */
+    public function getIntegrationAPI();
+
+    /**
+     * @return mixed
+     */
+    public function getLogger();
+
+    /**
+     * @return mixed
+     */
+    public function getDataStore();
+}

--- a/src/Router/DefaultRestAPIRouter.php
+++ b/src/Router/DefaultRestAPIRouter.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace CF\Router;
+
+use CF\API\APIInterface;
+use CF\API\Client;
+use CF\API\Request;
+use CF\Integration\IntegrationInterface;
+
+class DefaultRestAPIRouter implements RouterInterface
+{
+    private $api;
+    private $dataStore;
+    private $integration;
+    private $integrationAPI;
+    private $logger;
+    private $routes;
+
+    const ENDPOINT = 'https://api.cloudflare.com/client/v4/';
+
+    // Placeholders you can use to pattern match part of a URI
+    public static $API_ROUTING_PLACEHOLDERS = array(
+        ':id' => '[0-9a-z]{32}',
+        ':bigint_id' => '[0-9]{1,19}',
+        ':human_readable_id' => '[-0-9a-z_]{1,120}',
+        ':rayid' => '[0-9a-z]{16}',
+        ':firewall_rule_id' => '[0-9a-zA-Z\\-_]{1,160}',
+        ':file_name' => '[0-9A-Za-z_\\.\\-]{1,120}',
+        ':uuid' => '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}',
+    );
+
+    /**
+     * @param IntegrationInterface $integration
+     * @param APIInterface         $api
+     * @param $routes
+     */
+    public function __construct(IntegrationInterface $integration, APIInterface $api, $routes)
+    {
+        $this->api = $api;
+        $this->dataStore = $integration->getDataStore();
+        $this->integration = $integration;
+        $this->integrationAPI = $integration->getIntegrationAPI();
+        $this->logger = $integration->getLogger();
+        $this->routes = $routes;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function route(Request $request)
+    {
+        $request->setUrl($this->api->getPath($request));
+
+        $routeParameters = $this->getRoute($request);
+        if ($routeParameters) {
+            $class = $routeParameters['class'];
+            $function = $routeParameters['function'];
+            $routeClass = new $class($this->integration, $this->api, $request);
+
+            return $routeClass->$function();
+        } else {
+            return $this->api->callAPI($request);
+        }
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function getPath(Request $request)
+    {
+        //substring of everything after the endpoint is the path
+        return substr($request->getUrl(), strpos($request->getUrl(), $this->api->getEndpoint()) + strlen($this->api->getEndpoint()));
+    }
+    
+    /**
+     * @param Request $request
+     *
+     * @return array|bool
+     */
+    public function getRoute(Request $request)
+    {
+        /*
+         * This method allows CPanel to hook into our API calls that require Cpanel specific functionality.
+         * Be VERY careful editing it, make sure you're code only fires for the specific API call you need to interact with.
+         */
+
+        //Load up our routes and replace their placeholders (i.e. :id changes to [0-9a-z]{32})
+        foreach ($this->routes as $routeKey => $route_details_array) {
+            //Replace placeholders in route
+            $regex = str_replace(
+                array_keys(static::$API_ROUTING_PLACEHOLDERS),
+                array_values(static::$API_ROUTING_PLACEHOLDERS),
+                $routeKey
+            );
+
+            //Check to see if this is our route
+            if (preg_match('#^'.$regex.'/?$#', $request->getUrl())) {
+                if (in_array($request->getMethod(), $route_details_array['methods']) || array_key_exists(
+                    $request->getMethod(),
+                    $route_details_array['methods']
+                )
+                ) {
+                    $this->logger->debug('Route matched for '.$request->getMethod().$request->getUrl().' now using '.$route_details_array['methods'][$request->getMethod()]['function']);
+
+                    return array(
+                        'class' => $route_details_array['class'],
+                        'function' => $route_details_array['methods'][$request->getMethod()]['function'],
+                    );
+                }
+            }
+        }
+
+        //if no route was found call our API normally
+        return false;
+    }
+
+    /**
+     * @return Client
+     */
+    public function getAPIClient()
+    {
+        return $this->api;
+    }
+
+    /**
+     * @param $routes
+     */
+    public function setRoutes($routes)
+    {
+        $this->routes = $routes;
+    }
+}

--- a/src/Router/RequestRouter.php
+++ b/src/Router/RequestRouter.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace CF\Router;
+
+use CF\API\Request;
+use CF\API\APIInterface;
+use CF\Integration\IntegrationInterface;
+
+class RequestRouter
+{
+    protected $integrationContext;
+
+    protected $routerList;
+
+    /**
+     * @param IntegrationInterface $integrationContext
+     */
+    public function __construct(IntegrationInterface $integrationContext)
+    {
+        $this->integrationContext = $integrationContext;
+        $this->routerList = array();
+    }
+
+    /**
+     * @param APIInterface $client
+     * @param $routes
+     */
+    public function addRouter(APIInterface $client, $routes)
+    {
+        $router = new DefaultRestAPIRouter($this->integrationContext, $client, $routes);
+        $this->routerList[$client->getAPIClientName()] = $router;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRouterList()
+    {
+        return $this->routerList;
+    }
+
+    /**
+     * @param $routerList
+     */
+    public function setRouterList($routerList)
+    {
+        $this->routerList = $routerList;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public function route(Request $request)
+    {
+        foreach ($this->getRouterList() as $router) {
+            if ($router->getAPIClient()->shouldRouteRequest($request)) {
+                return $router->route($request);
+            }
+        }
+
+        return;
+    }
+}

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace CF\Router;
+
+use CF\API\Request;
+
+interface RouterInterface
+{
+    public function route(Request $request);
+    public function getAPIClient();
+}

--- a/src/SecurityUtil.php
+++ b/src/SecurityUtil.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace CF;
+
+class SecurityUtil
+{
+    /**
+     * @return bool|string
+     */
+    public static function generate16bytesOfSecureRandomData()
+    {
+        if (function_exists('random_bytes')) {
+            $randBytes = random_bytes(16);
+        } elseif (function_exists('mcrypt_create_iv')) {
+            srand();
+            $randBytes = mcrypt_create_iv(16);
+        } elseif (function_exists('openssl_random_pseudo_bytes')) {
+            $wasItSecure = false;
+            $randBytes = openssl_random_pseudo_bytes(16, $wasItSecure);
+            if ($wasItSecure === false) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        return bin2hex($randBytes);
+    }
+
+    /**
+     * @param $secret - string a cryptographically strong secret
+     * @param $user - string a piece of unique user data
+     * @param $timeValidUntil - int of time the token will be valid for in seconds
+     *
+     * @return string
+     */
+    public static function csrfTokenGenerate($secret, $user, $timeValidUntil = null)
+    {
+        if ($timeValidUntil === null) {
+            $timeValidUntil = time() + 86400;
+        }
+        $hashedSecret = hash('sha512', $secret);
+        $dataToHash = sprintf('%s-%s-%s', $hashedSecret, $user, $timeValidUntil);
+        $hashedData = static::hashFunction($dataToHash);
+
+        return sprintf('%s-%s', $timeValidUntil, $hashedData);
+    }
+
+    /**
+     * @param $secret - string a cryptographically strong secret
+     * @param $user - string a piece of unique user data
+     * @param $token- string the token that needs to be validated.
+     *
+     * @return bool
+     */
+    public static function csrfTokenValidate($secret, $user, $token)
+    {
+        $tokenParts = explode('-', $token);
+        if (count($tokenParts) !== 2) {
+            return false;
+        }
+
+        list($timeValidFor, $hash) = $tokenParts;
+
+        $hashedSecret = hash('sha512', $secret);
+        $dataToHash = sprintf('%s-%s-%s', $hashedSecret, $user, $timeValidFor);
+        $newHash = static::hashFunction($dataToHash);
+        if ($newHash !== $hash) {
+            return false;
+        }
+        if (time() > $timeValidFor) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param $data - string the data that will be hashed.
+     *
+     * @return string
+     */
+    private static function hashFunction($data)
+    {
+        $hash = hash('sha512', $data);
+
+        return substr($hash, 64);
+    }
+}

--- a/src/Test/API/AbstractAPIClientTest.php
+++ b/src/Test/API/AbstractAPIClientTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace CF\API\Test;
+
+use GuzzleHttp;
+use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\ResponseInterface;
+use CF\Integration\DefaultIntegration;
+use CF\Integration\DefaultLogger;
+use CF\Integration\DataStoreInterface;
+use CF\Integration\IntegrationAPIInterface;
+use CF\API\HttpClientInterface;
+use \CF\API\Request;
+use \CF\API\AbstractAPIClient;
+use \CF\Integration\DefaultConfig;
+
+class AbstractAPIClientTest extends \PHPUnit\Framework\TestCase
+{
+    protected $mockAbstractAPIClient;
+    protected $mockAPI;
+    protected $mockClient;
+    protected $mockConfig;
+    protected $mockDataStore;
+    protected $mockLogger;
+    protected $mockRequest;
+
+    const TOTAL_PAGES = 3;
+    const MOCK_RESPONSE = [
+        'result' => [],
+        'result_info' => [
+            'total_pages' => self::TOTAL_PAGES
+        ]
+    ];
+
+    public function setup(): void
+    {
+        $this->mockRequest = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockClient = $this->getMockBuilder(HttpClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockConfig = $this->getMockBuilder(DefaultConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockConfig->method('getValue')->willReturn(true);
+        $this->mockAPI = $this->getMockBuilder(IntegrationAPIInterface::class)
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder(DataStoreInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder(DefaultLogger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockIntegration = new DefaultIntegration($this->mockConfig, $this->mockAPI, $this->mockDataStore, $this->mockLogger);
+
+        $this->mockAbstractAPIClient = $this->getMockBuilder(AbstractAPIClient::class)
+            ->setConstructorArgs([$this->mockIntegration])
+            ->getMockForAbstractClass();
+        $this->mockAbstractAPIClient->setHttpClient($this->mockClient);
+    }
+
+    public function testGetPaginatedResultsRequestsAllPages()
+    {
+        $this->mockRequest->method('getMethod')->willReturn('GET');
+        $this->mockClient->expects($this->exactly((self::TOTAL_PAGES - 1)))->method('send')->willReturn([
+            'result' => []
+        ]);
+        $this->mockAbstractAPIClient->getPaginatedResults($this->mockRequest, self::MOCK_RESPONSE);
+    }
+
+    public function testGetPaginatedResultsOnlyExecutesForGET()
+    {
+        $methods = ['DELETE', 'PUT', 'PATCH', 'POST'];
+        $this->mockClient->expects($this->never())->method('send');
+
+        foreach ($methods as $method) {
+            $this->mockRequest = $this->getMockBuilder(Request::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $this->mockRequest->method('getMethod')->willReturn($method);
+            $this->mockAbstractAPIClient->getPaginatedResults($this->mockRequest, self::MOCK_RESPONSE);
+        }
+    }
+
+    public function testGetPaginatedResultsOnlyExecutesForPagedResults()
+    {
+        $this->mockClient->expects($this->never())->method('send');
+        $this->mockAbstractAPIClient->getPaginatedResults($this->mockRequest, []);
+    }
+
+    public function testGetPathReturnsPath()
+    {
+        $endpoint = 'http://api.cloudflare.com/client/v4';
+        $path = '/zones';
+        $this->mockRequest->method('getUrl')->willReturn($endpoint . $path);
+        $this->mockAbstractAPIClient->method('getEndpoint')->willReturn($endpoint);
+        $this->assertEquals($path, $this->mockAbstractAPIClient->getPath($this->mockRequest));
+    }
+
+    public function testShouldRouteRequestReturnsTrueForValidRequest()
+    {
+        $endpoint = 'http://api.cloudflare.com/client/v4';
+        $url = $endpoint . '/zones';
+        $this->mockRequest->method('getUrl')->willReturn($url);
+        $this->mockAbstractAPIClient->method('getEndpoint')->willReturn($endpoint);
+        $this->assertTrue($this->mockAbstractAPIClient->shouldRouteRequest($this->mockRequest));
+    }
+
+    public function testShouldRouteRequestReturnsFalseForInvalidRequest()
+    {
+        $this->mockRequest->method('getUrl')->willReturn('http://api.cloudflare.com/client/v4/zones');
+        $this->mockAbstractAPIClient->method('getEndpoint')->willReturn('https://api.cloudflare.com/host-gw.html');
+        $this->assertFalse($this->mockAbstractAPIClient->shouldRouteRequest($this->mockRequest));
+    }
+
+    public function testSendAndLogCallsLogger()
+    {
+        $this->mockLogger->expects($this->once())->method('error');
+        $this->mockAbstractAPIClient->sendAndLog($this->mockRequest);
+    }
+}

--- a/src/Test/API/AbstractPluginActionsTest.php
+++ b/src/Test/API/AbstractPluginActionsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace CF\API\Test;
+
+use CF\API\Plugin;
+
+class AbstractPluginActionsTest extends \PHPUnit\Framework\TestCase
+{
+    protected $mockAbstractPluginActions;
+    protected $mockAPIClient;
+    protected $mockClientAPI;
+    protected $mockDataStore;
+    protected $mockLogger;
+    protected $mockRequest;
+    protected $pluginActions;
+
+    public function setup(): void
+    {
+        $this->mockAPIClient = $this->getMockBuilder('\CF\API\Plugin')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockClientAPI = $this->getMockBuilder('\CF\API\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder('\CF\Integration\DataStoreInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder('\Psr\Log\LoggerInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockRequest = $this->getMockBuilder('\CF\API\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockAbstractPluginActions = $this->getMockBuilder('CF\API\AbstractPluginActions')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->mockDefaultIntegration = $this->getMockBuilder('\CF\Integration\DefaultIntegration')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->mockAbstractPluginActions->setAPI($this->mockAPIClient);
+        $this->mockAbstractPluginActions->setClientAPI($this->mockClientAPI);
+        $this->mockAbstractPluginActions->setDataStore($this->mockDataStore);
+        $this->mockAbstractPluginActions->setLogger($this->mockLogger);
+        $this->mockAbstractPluginActions->setRequest($this->mockRequest);
+    }
+
+    public function testPostAccountSaveAPICredentialsReturnsErrorIfMissingApiKey()
+    {
+        $this->mockRequest->method('getBody')->willReturn(array(
+            'email' => 'email',
+        ));
+        $this->mockAPIClient->method('createAPIError')->willReturn(array('success' => false));
+
+        $response = $this->mockAbstractPluginActions->login();
+
+        $this->assertFalse($response['success']);
+    }
+
+    public function testPostAccountSaveAPICredentialsReturnsErrorIfMissingEmail()
+    {
+        $this->mockRequest->method('getBody')->willReturn(array(
+            'apiKey' => 'apiKey',
+        ));
+        $this->mockAPIClient->method('createAPIError')->willReturn(array('success' => false));
+
+        $response = $this->mockAbstractPluginActions->login();
+
+        $this->assertFalse($response['success']);
+    }
+
+    public function testGetPluginSettingsReturnsArray()
+    {
+        $this->mockDataStore->method('get')->willReturn(array());
+        $this->mockAPIClient
+            ->expects($this->once())
+            ->method('createAPISuccessResponse')
+            ->will($this->returnCallback(function ($input) {
+                $this->assertTrue(is_array($input));
+            }));
+        $this->mockAbstractPluginActions->getPluginSettings();
+    }
+
+    public function testPatchPluginSettingsReturnsErrorForBadSetting()
+    {
+        $this->mockRequest->method('getUrl')->willReturn('plugin/:id/settings/nonExistentSetting');
+        $this->mockAPIClient->expects($this->once())->method('createAPIError');
+        $this->mockAbstractPluginActions->patchPluginSettings();
+    }
+
+    public function testGetPluginSettingsHandlesSuccess()
+    {
+        /*
+         * This assertion should fail as we add new settings and should be updated to reflect
+         * count(Plugin::getPluginSettingsKeys())
+         */
+        $this->mockDataStore->method('get')->willReturn(array());
+        $this->mockDataStore->expects($this->exactly(7))->method('get');
+        $this->mockAPIClient->expects($this->once())->method('createAPISuccessResponse');
+        $this->mockAbstractPluginActions->getPluginSettings();
+    }
+
+    public function testPatchPluginSettingsUpdatesSetting()
+    {
+        $value = 'value';
+        $settingId = 'settingId';
+        $this->mockRequest->method('getUrl')->willReturn('plugin/:zonedId/settings/' . $settingId);
+        $this->mockRequest->method('getBody')->willReturn(array($value => $value));
+        $this->mockDataStore->method('set')->willReturn(true);
+        $this->mockDataStore->expects($this->once())->method('set');
+        $this->mockAPIClient->expects($this->once())->method('createAPISuccessResponse');
+        $this->mockAbstractPluginActions->patchPluginSettings();
+    }
+
+    public function testPatchPluginSettingsReturnsErrorIfSettingUpdateFails()
+    {
+        $value = 'value';
+        $settingId = 'settingId';
+        $this->mockRequest->method('getUrl')->willReturn('plugin/:zonedId/settings/' . $settingId);
+        $this->mockRequest->method('getBody')->willReturn(array($value => $value));
+        $this->mockDataStore->method('set')->willReturn(null);
+        $this->mockDataStore->expects($this->once())->method('set');
+        $this->mockAPIClient->expects($this->once())->method('createAPIError');
+        $this->mockAbstractPluginActions->patchPluginSettings();
+    }
+
+    public function testLoginReturnsErrorIfAPIKeyOrEmailAreInvalid()
+    {
+        $apiKey = 'apiKey';
+        $email = 'email';
+        $this->mockRequest->method('getBody')->willReturn(array(
+            $apiKey => $apiKey,
+            $email => $email,
+        ));
+        $this->mockDataStore->method('createUserDataStore')->willReturn(true);
+        $this->mockClientAPI->method('responseOk')->willReturn(false);
+
+        $this->mockAPIClient->expects($this->once())->method('createAPIError');
+        $this->mockAbstractPluginActions->login();
+    }
+
+    public function testGetPluginSettingsCallsCreatePluginSettingObjectIfDataStoreGetIsNull()
+    {
+        $this->mockDataStore->method('get')->willReturn(null);
+        $this->mockAPIClient->expects($this->atLeastOnce())->method('createPluginSettingObject');
+        $this->mockAbstractPluginActions->getPluginSettings();
+    }
+
+    public function testPatchPluginSettingsCallsApplyDefaultSettingsIfSettingIsDefaultSettings()
+    {
+        $settingId = 'default_settings';
+        $this->mockRequest->method('getUrl')->willReturn('plugin/:zonedId/settings/' . $settingId);
+        $this->mockDataStore->method('set')->willReturn(true);
+        $this->mockAbstractPluginActions->expects($this->once())->method('applyDefaultSettings');
+        $this->mockAbstractPluginActions->patchPluginSettings();
+    }
+
+    public function testGetUserConfigReturnsEmptyJson()
+    {
+        $this->mockAPIClient->expects($this->once())->method('createAPISuccessResponse')->with([]);
+        $this->mockAbstractPluginActions->getConfig();
+    }
+}

--- a/src/Test/API/ClientTest.php
+++ b/src/Test/API/ClientTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace CF\API\Test;
+
+use CF\API\Client;
+use CF\Integration\DefaultIntegration;
+
+class ClientTest extends \PHPUnit\Framework\TestCase
+{
+    private $mockConfig;
+    private $mockClientAPI;
+    private $mockAPI;
+    private $mockDataStore;
+    private $mockLogger;
+    private $mockCpanelIntegration;
+
+    public function setup(): void
+    {
+        $this->mockConfig = $this->getMockBuilder('CF\Integration\DefaultConfig')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockAPI = $this->getMockBuilder('CF\Integration\IntegrationAPIInterface')
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder('CF\Integration\DataStoreInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder('CF\Integration\DefaultLogger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockCpanelIntegration = new DefaultIntegration($this->mockConfig, $this->mockAPI, $this->mockDataStore, $this->mockLogger);
+
+        $this->mockClientAPI = new Client($this->mockCpanelIntegration);
+    }
+
+    public function testBeforeSendAddsRequestHeaders()
+    {
+        $apiKey = '41db178adf2ef1c82c84db6ca455457646d33';
+        $email = 'test@email.com';
+
+        $this->mockDataStore->method('getClientV4APIKey')->willReturn($apiKey);
+        $this->mockDataStore->method('getCloudFlareEmail')->willReturn($email);
+
+        $request = new \CF\API\Request(null, null, null, null);
+        $beforeSendRequest = $this->mockClientAPI->beforeSend($request);
+
+        $actualRequestHeaders = $beforeSendRequest->getHeaders();
+        $expectedRequestHeaders = array(
+            Client::X_AUTH_KEY => $apiKey,
+            Client::X_AUTH_EMAIL => $email,
+            Client::CONTENT_TYPE_KEY => Client::APPLICATION_JSON_KEY,
+        );
+
+        $this->assertEquals($expectedRequestHeaders[Client::X_AUTH_KEY], $actualRequestHeaders[Client::X_AUTH_KEY]);
+        $this->assertEquals($expectedRequestHeaders[Client::X_AUTH_EMAIL], $actualRequestHeaders[Client::X_AUTH_EMAIL]);
+        $this->assertEquals($expectedRequestHeaders[Client::CONTENT_TYPE_KEY], $actualRequestHeaders[Client::CONTENT_TYPE_KEY]);
+    }
+
+    public function testClientApiErrorReturnsValidStructure()
+    {
+        $expectedErrorResponse = array(
+            'result' => null,
+            'success' => false,
+            'errors' => array(
+                array(
+                    'code' => '',
+                    'message' => 'Test Message',
+                ),
+            ),
+            'messages' => array(),
+        );
+        $errorResponse = $this->mockClientAPI->createAPIError('Test Message');
+        $this->assertEquals($errorResponse, $expectedErrorResponse);
+    }
+
+    public function testResponseOkReturnsTrueForValidResponse()
+    {
+        $v4APIResponse = array(
+            'success' => true,
+        );
+
+        $this->assertTrue($this->mockClientAPI->responseOk($v4APIResponse));
+    }
+
+    public function testGetErrorMessageSuccess()
+    {
+        $errorMessage = 'I am an error message';
+
+        $error = $this->getMockBuilder('\Guzzle\Http\Exception\BadResponseException')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getResponse', 'getBody', 'getMessage'))
+            ->getMock();
+
+        $errorJSON = json_encode(
+            array(
+                'success' => false,
+                'errors' => array(
+                    array(
+                        'message' => $errorMessage,
+                    ),
+                ),
+            )
+        );
+
+        $error->expects($this->any())
+            ->method('getMessage')
+            ->will($this->returnValue('Not this message'));
+        $error->expects($this->any())
+            ->method('getResponse')
+            ->will($this->returnSelf());
+        $error->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue($errorJSON));
+
+        $this->assertEquals($errorMessage, $this->mockClientAPI->getErrorMessage($error));
+    }
+}

--- a/src/Test/API/DefaultHttpClientTest.php
+++ b/src/Test/API/DefaultHttpClientTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace CF\API\Test;
+
+use GuzzleHttp;
+use CF\API\DefaultHttpClient;
+use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\ResponseInterface;
+use \CF\API\Request;
+
+class DefaultHttpClientTest extends \PHPUnit\Framework\TestCase
+{
+    protected $mockClient;
+    protected $mockGuzzleRequest;
+    protected $mockGuzzleResponse;
+    protected $mockRequest;
+
+    public function setup(): void
+    {
+        $this->mockClient = $this->getMockBuilder(GuzzleHttp\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockGuzzleRequest = $this->getMockBuilder(RequestInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockClient->method('createRequest')->willReturn($this->mockGuzzleRequest);
+
+        $this->mockGuzzleResponse = $this->getMockBuilder(ResponseInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockClient->method('send')->willReturn($this->mockGuzzleResponse);
+
+        $this->mockRequest = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->defaultHttpClient = new DefaultHttpClient("endpoint");
+        $this->defaultHttpClient->setClient($this->mockClient);
+    }
+
+    public function testSendRequestCallsGuzzleSend()
+    {
+        $this->mockGuzzleResponse->method('json')->willReturn(true);
+        $this->mockClient->expects($this->once())->method('send');
+
+        $this->defaultHttpClient->send($this->mockRequest);
+    }
+
+    public function testCreateGuzzleRequestReturnsGuzzleRequest()
+    {
+        $this->assertInstanceOf(RequestInterface::class, $this->defaultHttpClient->createGuzzleRequest($this->mockRequest));
+    }
+}

--- a/src/Test/API/HostTest.php
+++ b/src/Test/API/HostTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace CF\API\Test;
+
+use CF\API\Host;
+use CF\API\Request;
+use CF\Integration\DefaultIntegration;
+
+class HostTest extends \PHPUnit\Framework\TestCase
+{
+    private $hostAPI;
+    private $mockConfig;
+    private $mockAPI;
+    private $mockDataStore;
+    private $mockLogger;
+    private $mockCpanelIntegration;
+
+    public function setup(): void
+    {
+        $this->mockConfig = $this->getMockBuilder('CF\Integration\DefaultConfig')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockAPI = $this->getMockBuilder('CF\Integration\IntegrationAPIInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder('CF\Integration\DataStoreInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder('CF\Integration\DefaultLogger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockCpanelIntegration = new DefaultIntegration($this->mockConfig, $this->mockAPI, $this->mockDataStore, $this->mockLogger);
+
+        $this->hostAPI = new Host($this->mockCpanelIntegration);
+    }
+
+    public function testBeforeSendSetsCorrectPath()
+    {
+        $request = new Request(null, null, null, null);
+        $request = $this->hostAPI->beforeSend($request);
+
+        $this->assertEquals(Host::ENDPOINT_PATH, $request->getUrl());
+    }
+
+    public function testBeforeSendSetsIntegrationHeaders()
+    {
+        $integrationName = 'integrationName';
+        $version = 'version';
+
+        $this->mockConfig->method('getValue')->will(
+            $this->returnValueMap(
+                array(
+                    array($integrationName, $integrationName),
+                    array($version, $version),
+                )
+            )
+        );
+
+        $request = new Request(null, null, null, null);
+        $request = $this->hostAPI->beforeSend($request);
+
+        $requestHeaders = $request->getHeaders();
+
+        $this->assertEquals($integrationName, $requestHeaders[Host::CF_INTEGRATION_HEADER]);
+        $this->assertEquals($version, $requestHeaders[Host::CF_INTEGRTATION_VERSION_HEADER]);
+    }
+
+    public function testBeforeSendSetsUserKeyforActZoneSet()
+    {
+        $userKey = 'userKey';
+        $this->mockDataStore->method('getHostAPIUserKey')->willReturn($userKey);
+
+        $request = new Request(null, null, null, array('act' => 'zone_set'));
+        $request = $this->hostAPI->beforeSend($request);
+
+        $requestBody = $request->getBody();
+
+        $this->assertEquals($userKey, $requestBody['user_key']);
+    }
+
+    public function testBeforeSendSetsUserKeyforActFullZoneSet()
+    {
+        $userKey = 'userKey';
+        $this->mockDataStore->method('getHostAPIUserKey')->willReturn($userKey);
+
+        $request = new Request(null, null, null, array('act' => 'full_zone_set'));
+        $request = $this->hostAPI->beforeSend($request);
+
+        $requestBody = $request->getBody();
+
+        $this->assertEquals($userKey, $requestBody['user_key']);
+    }
+
+    public function testBeforeSendSetsHostKey()
+    {
+        $hostKey = 'hostKey';
+        $this->mockAPI->method('getHostAPIKey')->willReturn($hostKey);
+
+        $request = new Request(null, null, null, null);
+        $request = $this->hostAPI->beforeSend($request);
+
+        $requestBody = $request->getBody();
+
+        $this->assertEquals($hostKey, $requestBody['host_key']);
+    }
+
+    public function testResponseOkReturnsTrueForValidResponse()
+    {
+        $hostAPIResponse = array(
+            'result' => 'success',
+        );
+
+        $this->assertTrue($this->hostAPI->responseOk($hostAPIResponse));
+    }
+
+    public function testClientApiErrorReturnsValidStructure()
+    {
+        $message = 'message';
+
+        $errorResponse = $this->hostAPI->createAPIError($message);
+
+        $this->assertEquals($message, $errorResponse['msg']);
+        $this->assertEquals('error', $errorResponse['result']);
+    }
+
+    public function testGetPathReturnsBodyActParameter()
+    {
+        $act = 'act';
+        $request = new Request(null, null, null, array($act => $act));
+        $this->assertEquals($act, $this->hostAPI->getPath($request));
+    }
+
+    public function testShouldRouteRequestReturnsTrueIfUrlsAreEqual()
+    {
+        $request = new Request(null, Host::ENDPOINT, null, null);
+        $this->assertTrue($this->hostAPI->shouldRouteRequest($request));
+    }
+}

--- a/src/Test/API/PluginTest.php
+++ b/src/Test/API/PluginTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CF\Test\API;
+
+use CF\Integration\DefaultIntegration;
+use CF\API\Plugin;
+
+class PluginTest extends \PHPUnit\Framework\TestCase
+{
+    private $mockConfig;
+    private $mockWordPressAPI;
+    private $mockDataStore;
+    private $mockLogger;
+    private $mockDefaultIntegration;
+    private $mockRequest;
+    private $pluginAPIClient;
+
+    public function setup(): void
+    {
+        $this->mockConfig = $this->getMockBuilder('CF\Integration\DefaultConfig')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockWordPressAPI = $this->getMockBuilder('CF\Integration\IntegrationAPIInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder('CF\Integration\DataStoreInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder('CF\Integration\DefaultLogger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockRequest = $this->getMockBuilder('CF\API\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockDefaultIntegration = new DefaultIntegration($this->mockConfig, $this->mockWordPressAPI, $this->mockDataStore, $this->mockLogger);
+        $this->pluginAPIClient = new Plugin($this->mockDefaultIntegration);
+    }
+
+    public function testCreateAPISuccessResponse()
+    {
+        $resultString = 'result';
+        $resultArray = array('email' => $resultString);
+
+        $firstResponse = $this->pluginAPIClient->createAPISuccessResponse($resultString);
+        $secondResponse = $this->pluginAPIClient->createAPISuccessResponse($resultArray);
+
+        $this->assertTrue($firstResponse['success']);
+        $this->assertTrue($secondResponse['success']);
+        $this->assertEquals($resultString, $firstResponse['result']);
+        $this->assertEquals($resultArray, $secondResponse['result']);
+    }
+
+    public function testCreateAPIErrorReturnsError()
+    {
+        $response = $this->pluginAPIClient->createAPIError('error Message');
+
+        $this->assertFalse($response['success']);
+    }
+
+    public function testCallAPIReturnsError()
+    {
+        $response = $this->pluginAPIClient->callAPI($this->mockRequest);
+
+        $this->assertFalse($response['success']);
+    }
+
+    public function testCreatePluginSettingObject()
+    {
+        $pluginSettingKey = 'key';
+        $value = 'value';
+        $editable = false;
+        $modifiedOn = null;
+
+        $expected = array(
+            Plugin::SETTING_ID_KEY => $pluginSettingKey,
+            Plugin::SETTING_VALUE_KEY => $value,
+            Plugin::SETTING_EDITABLE_KEY => $editable,
+            Plugin::SETTING_MODIFIED_DATE_KEY => $modifiedOn,
+        );
+
+        $result = $this->pluginAPIClient->createPluginSettingObject($pluginSettingKey, $value, $editable, $modifiedOn);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testCreatePluginSettingObjectReturnsISO8061DateForNonNullValue()
+    {
+        $result = $this->pluginAPIClient->createPluginSettingObject(null, null, null, true);
+        //DateTime() will throw an exception if $result['modified_on'] isn't a valid date
+        $this->assertInstanceOf('\DateTime', new \DateTime($result['modified_on']));
+    }
+}

--- a/src/Test/Integration/DefaultConfigTest.php
+++ b/src/Test/Integration/DefaultConfigTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CF\Integration\Test;
+
+use CF\Integration\DefaultConfig;
+
+class DefaultConfigTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetValueReturnsCorrectValue()
+    {
+        $key = 'key';
+        $value = 'value';
+        $config = new DefaultConfig(json_encode(array($key => $value)));
+        $this->assertEquals($value, $config->getValue($key));
+    }
+}

--- a/src/Test/Integration/DefaultLoggerTest.php
+++ b/src/Test/Integration/DefaultLoggerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CF\Integration\Test;
+
+use CF\Integration\DefaultLogger;
+
+class DefaultLoggerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDebugLogOnlyLogsIfDebugIsEnabled()
+    {
+        $logger = new DefaultLogger(true);
+        $returnValue = $logger->debug('');
+        $this->assertTrue($returnValue);
+
+        $logger = new DefaultLogger(false);
+        $returnValue = $logger->debug('');
+        $this->assertNull($returnValue);
+    }
+}

--- a/src/Test/Router/DefaultRestAPIRouterTest.php
+++ b/src/Test/Router/DefaultRestAPIRouterTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace CF\Router\Test;
+
+use CF\API\Request;
+use CF\Integration\DefaultIntegration;
+use CF\Router\DefaultRestAPIRouter;
+
+class DefaultRestAPIRouterTest extends \PHPUnit\Framework\TestCase
+{
+    private $clientV4APIRouter;
+    private $mockConfig;
+    private $mockClientAPI;
+    private $mockAPI;
+    private $mockIntegration;
+    private $mockDataStore;
+    private $mockLogger;
+    private $mockRoutes = array();
+
+    public function setup(): void
+    {
+        $this->mockConfig = $this->getMockBuilder('CF\Integration\DefaultConfig')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockClientAPI = $this->getMockBuilder('CF\API\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockAPI = $this->getMockBuilder('CF\Integration\IntegrationAPIInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder('CF\Integration\DataStoreInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder('CF\Integration\DefaultLogger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockIntegration = new DefaultIntegration($this->mockConfig, $this->mockAPI, $this->mockDataStore, $this->mockLogger);
+        $this->clientV4APIRouter = new DefaultRestAPIRouter($this->mockIntegration, $this->mockClientAPI, $this->mockRoutes);
+    }
+
+    public function testGetRouteReturnsClassFunctionForValidRoute()
+    {
+        $routes = array(
+            'zones' => array(
+                'class' => 'testClass',
+                'methods' => array(
+                    'GET' => array(
+                        'function' => 'testFunction',
+                    ),
+                ),
+            ),
+        );
+        $this->clientV4APIRouter->setRoutes($routes);
+
+        $request = new Request('GET', 'zones', array(), array());
+
+        $response = $this->clientV4APIRouter->getRoute($request);
+
+        $this->assertEquals(array(
+            'class' => 'testClass',
+            'function' => 'testFunction',
+        ), $response);
+    }
+
+    public function testGetRouteReturnsFalseForNoRouteFound()
+    {
+        $request = new Request('GET', 'zones', array(), array());
+        $response = $this->clientV4APIRouter->getRoute($request);
+        $this->assertFalse($response);
+    }
+}

--- a/src/Test/Router/RequestRouterTest.php
+++ b/src/Test/Router/RequestRouterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CF\Router\Test;
+
+use CF\API\Client;
+use CF\API\Request;
+use CF\Integration\DefaultConfig;
+use CF\Integration\DefaultLogger;
+use CF\Integration\DefaultIntegration;
+use CF\Integration\DataStoreInterface;
+use CF\Integration\IntegrationAPIInterface;
+use CF\Router\RequestRouter;
+use CF\Router\DefaultRestAPIRouter;
+
+class RequestRouterTest extends \PHPUnit\Framework\TestCase
+{
+    protected $mockConfig;
+    protected $mockClient;
+    protected $mockAPI;
+    protected $mockIntegration;
+    protected $mockDataStore;
+    protected $mockLogger;
+    protected $mockRequest;
+    protected $requestRouter;
+
+    public function setup(): void
+    {
+        $this->mockConfig = $this->getMockBuilder(DefaultConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockClient = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockAPI = $this->getMockBuilder(IntegrationAPIInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockDataStore = $this->getMockBuilder(DataStoreInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockLogger = $this->getMockBuilder(DefaultLogger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mockIntegration = new DefaultIntegration($this->mockConfig, $this->mockAPI, $this->mockDataStore, $this->mockLogger);
+
+        $this->mockRequest = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->requestRouter = new RequestRouter($this->mockIntegration);
+    }
+
+    public function testAddRouterAddsRouter()
+    {
+        $clientName = "clientName";
+        $this->mockClient->method('getAPIClientName')->willReturn($clientName);
+
+        $this->requestRouter->addRouter($this->mockClient, null);
+        $this->assertEquals(DefaultRestAPIRouter::class, get_class($this->requestRouter->getRouterList()[$clientName]));
+    }
+
+    public function testRoutePassesValidRequestToDefaultRestAPIRouter()
+    {
+        $mockDefaultRestAPIRouter = $this->getMockBuilder('CF\Router\DefaultRestAPIRouter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockAPIClient = $this->getMockBuilder('CF\API\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockAPIClient->method('shouldRouteRequest')->willReturn(true);
+        $mockDefaultRestAPIRouter->method('getAPIClient')->willReturn($mockAPIClient);
+        $mockDefaultRestAPIRouter->expects($this->once())->method('route');
+
+        $this->requestRouter->setRouterList(array($mockDefaultRestAPIRouter));
+
+        $this->requestRouter->route($this->mockRequest);
+    }
+}

--- a/src/Test/SecurityUtilTest.php
+++ b/src/Test/SecurityUtilTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CF;
+
+class SecurityUtilTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCSRFTokenValidateReturnsTrueForValidToken()
+    {
+        $secret = 'secret';
+        $user = 'user';
+        $token = SecurityUtil::csrfTokenGenerate($secret, $user);
+        $this->assertTrue(SecurityUtil::csrfTokenValidate($secret, $user, $token));
+    }
+
+    public function testCSRFTokenValidateReturnsFalseForInvalidToken()
+    {
+        $secret = 'secret';
+        $user = 'user';
+        $timeValidUntil = time() + 86400;
+        $token = SecurityUtil::csrfTokenGenerate($secret, $user, $timeValidUntil);
+        $this->assertFalse(SecurityUtil::csrfTokenValidate('bad secret', $user, $token));
+    }
+
+    public function testCSRFTokenValidateReturnsFalseForExpiredToken()
+    {
+        $secret = 'secret';
+        $user = 'user';
+        $timeValidUntil = time() - 1;
+        $token = SecurityUtil::csrfTokenGenerate($secret, $user, $timeValidUntil);
+        $this->assertFalse(SecurityUtil::csrfTokenValidate($secret, $user, $token));
+    }
+}

--- a/src/Test/WordPress/ClientActionsTest.php
+++ b/src/Test/WordPress/ClientActionsTest.php
@@ -62,7 +62,7 @@ class ClientActionsTest extends \PHPUnit\Framework\TestCase
                     'name' => $responseDomain,
                 ),
             ),
-         );
+        );
 
         $request = new Request(null, null, null, null);
         $clientActions = new ClientActions($this->mockDefaultIntegration, $this->mockClientAPI, $request);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CF;
+
+class Utils
+{
+    /*
+     * @return string
+     */
+    public static function getCurrentDate()
+    {
+        // Format ISO 8601
+        return date('c');
+    }
+}


### PR DESCRIPTION
For a long time, we had multiple integrations that relied on the 
`cloudflare-plugin-backend` repository to hold shared dependencies and 
functionality. This isn't the case anymore and just adds overhead to the release 
process of this plugin. 

Instead, move everything from `cloudflare-plugin-backend` into the `src` 
directory and make sure the dependencies all match.