### PR TITLE
Remove Guzzle in favor of WordPress core functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.DS_Store
 vendor/
 xdebug/*
+.phpunit.result.cache

--- a/Dockerfile.wordpress
+++ b/Dockerfile.wordpress
@@ -1,5 +1,5 @@
 FROM wpdiaries/wordpress-xdebug:5.7-php7.4-apache
-RUN apt-get update && apt-get install -y git-core vim
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y git-core vim
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "require": {
         "cloudflare/cf-ip-rewrite": "^1.0.0",
         "symfony/polyfill-intl-idn": "*",
-        "psr/log": "^1.0",
-        "guzzlehttp/guzzle": "~5.0"
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bda85e02cc5ade00c792494d86651a6d",
+    "content-hash": "b761074c6fbb1d89ee733fced27babca",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",
@@ -52,162 +52,6 @@
             "time": "2017-10-10T15:44:33+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "5.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b87eda7a7162f95574032da17e9323c9899cb6b2",
-                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/ringphp": "^1.1",
-                "php": ">=5.4.0",
-                "react/promise": "^2.2"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "^4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2019-10-30T09:32:00+00:00"
-        },
-        {
-            "name": "guzzlehttp/ringphp",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
-                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/streams": "~3.0",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "abandoned": true,
-            "time": "2018-07-31T13:22:33+00:00"
-        },
-        {
-            "name": "guzzlehttp/streams",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "abandoned": true,
-            "time": "2014-10-12T19:18:40+00:00"
-        },
-        {
             "name": "psr/log",
             "version": "1.1.4",
             "source": {
@@ -253,52 +97,6 @@
                 "psr-3"
             ],
             "time": "2021-05-03T11:20:27+00:00"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "keywords": [
-                "promise",
-                "promises"
-            ],
-            "time": "2020-05-12T15:16:56+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -2662,5 +2460,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -62,7 +62,7 @@ abstract class AbstractAPIClient implements APIInterface
             $response = $this->getPaginatedResults($request, $response);
 
             return $response;
-        } catch (RequestException $e) {
+        } catch (\Exception $e) {
             $errorMessage = $this->getErrorMessage($e);
 
             $this->logAPICall($this->getAPIClientName(), array(

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -2,7 +2,6 @@
 
 namespace CF\API;
 
-use Guzzle\Http\Exception\BadResponseException;
 use CF\Integration\IntegrationInterface;
 use CF\WordPress\Utils;
 

--- a/src/API/DefaultHttpClient.php
+++ b/src/API/DefaultHttpClient.php
@@ -31,7 +31,7 @@ class DefaultHttpClient implements HttpClientInterface
 
         $response = wp_remote_request($url, $requestOptions);
 
-        if(is_wp_error($response)) {
+        if (is_wp_error($response)) {
             throw new \Exception('Request error', $response->get_error_code);
         }
 
@@ -66,7 +66,7 @@ class DefaultHttpClient implements HttpClientInterface
     public function createRequestUrl(Request $request)
     {
         $url = $this->endpoint . $request->getUrl();
-        foreach($request->getParameters() as $key => $value) {
+        foreach ($request->getParameters() as $key => $value) {
             $url = add_query_arg($key, $value, $url);
         }
 

--- a/src/API/DefaultHttpClient.php
+++ b/src/API/DefaultHttpClient.php
@@ -38,7 +38,7 @@ class DefaultHttpClient implements HttpClientInterface
         $response_body = json_decode($response['body']);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \Exception('Error decoding client API JSON', $response);
+            throw new \Exception('Error decoding client API JSON', json_last_error());
         }
 
         return $response_body;

--- a/src/API/DefaultHttpClient.php
+++ b/src/API/DefaultHttpClient.php
@@ -3,67 +3,73 @@
 namespace CF\API;
 
 use CF\API\Request;
-use GuzzleHttp;
-use GuzzleHttp\Exception\RequestException;
 
 class DefaultHttpClient implements HttpClientInterface
 {
     const CONTENT_TYPE_KEY = 'Content-Type';
     const APPLICATION_JSON_KEY = 'application/json';
 
-    protected $client;
+    protected $endpoint;
 
     /**
      * @param String $endpoint
      */
     public function __construct($endpoint)
     {
-        $this->client = new GuzzleHttp\Client(['base_url' => $endpoint]);
+        $this->endpoint = $endpoint;
     }
 
     /**
      * @param  Request $request
-     * @throws RequestException
+     * @throws \Exception
      * @return Array $response
      */
     public function send(Request $request)
     {
-        $apiRequest = $this->createGuzzleRequest($request);
+        $requestOptions = $this->createRequestOptions($request);
+        $url = $this->createRequestUrl($request);
 
-        $response = $this->client->send($apiRequest)->json();
+        $response = wp_remote_request($url, $requestOptions);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new RequestException('Error decoding client API JSON', $response);
+        if(is_wp_error($response)) {
+            throw new \Exception('Request error', $response->get_error_code);
         }
 
-        return $response;
+        $response_body = json_decode($response['body']);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception('Error decoding client API JSON', $response);
+        }
+
+        return $response_body;
     }
 
     /**
      * @param  Request $request
-     * @return GuzzleHttp\Message\RequestInterface $request
+     * @return array $requestOptions
      */
-    public function createGuzzleRequest(Request $request)
+    public function createRequestOptions(Request $request)
     {
-        $bodyType = 'body';
-        if (isset($request->getHeaders()[self::CONTENT_TYPE_KEY]) && $request->getHeaders()[self::CONTENT_TYPE_KEY] === self::APPLICATION_JSON_KEY) {
-            $bodyType = 'json';
-        }
-
         $requestOptions = array(
+            'method' => $request->getMethod(),
             'headers' => $request->getHeaders(),
-            'query' => $request->getParameters(),
-            $bodyType => $request->getBody(),
+            'body' => $request->getBody(),
         );
 
-        return $this->client->createRequest($request->getMethod(), $request->getUrl(), $requestOptions);
+        return $requestOptions;
     }
 
     /**
-     * @param GuzzleHttpClient $client
+     * @param  Request $request
+     * @return string $url
      */
-    public function setClient($client)
+    public function createRequestUrl(Request $request)
     {
-        $this->client = $client;
+        $url = $this->endpoint . $request->getUrl();
+        foreach($request->getParameters() as $key => $value) {
+            $url = add_query_arg($key, $value, $url);
+        }
+
+        return $url;
     }
 }

--- a/src/Test/API/AbstractAPIClientTest.php
+++ b/src/Test/API/AbstractAPIClientTest.php
@@ -2,9 +2,6 @@
 
 namespace CF\API\Test;
 
-use GuzzleHttp;
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
 use CF\Integration\DefaultIntegration;
 use CF\Integration\DefaultLogger;
 use CF\Integration\DataStoreInterface;

--- a/src/Test/API/DefaultHttpClientTest.php
+++ b/src/Test/API/DefaultHttpClientTest.php
@@ -2,52 +2,24 @@
 
 namespace CF\API\Test;
 
-use GuzzleHttp;
 use CF\API\DefaultHttpClient;
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
 use \CF\API\Request;
 
 class DefaultHttpClientTest extends \PHPUnit\Framework\TestCase
 {
-    protected $mockClient;
-    protected $mockGuzzleRequest;
-    protected $mockGuzzleResponse;
     protected $mockRequest;
 
     public function setup(): void
     {
-        $this->mockClient = $this->getMockBuilder(GuzzleHttp\Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->mockGuzzleRequest = $this->getMockBuilder(RequestInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->mockClient->method('createRequest')->willReturn($this->mockGuzzleRequest);
-
-        $this->mockGuzzleResponse = $this->getMockBuilder(ResponseInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->mockClient->method('send')->willReturn($this->mockGuzzleResponse);
-
         $this->mockRequest = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->defaultHttpClient = new DefaultHttpClient("endpoint");
-        $this->defaultHttpClient->setClient($this->mockClient);
     }
 
-    public function testSendRequestCallsGuzzleSend()
+    public function testCreateRequestOptionsReturnsArray()
     {
-        $this->mockGuzzleResponse->method('json')->willReturn(true);
-        $this->mockClient->expects($this->once())->method('send');
-
-        $this->defaultHttpClient->send($this->mockRequest);
-    }
-
-    public function testCreateGuzzleRequestReturnsGuzzleRequest()
-    {
-        $this->assertInstanceOf(RequestInterface::class, $this->defaultHttpClient->createGuzzleRequest($this->mockRequest));
+        $this->assertIsArray($this->defaultHttpClient->createRequestOptions($this->mockRequest));
     }
 }


### PR DESCRIPTION
Closes #445 

This PR is _probably_ incomplete. A couple notes:

- Moves away from Guzzle exception classes. Replaced with what I considered sensible alternatives, but this will alter the logs that result from failed requests
- Inexperienced with stubbing WordPress core functions, so you may desire more comprehensive testing
- Docker image wouldn't build w/o adding an argument to `apt-get update`

But that said, all tests pass and I'll be giving this a go on a staging client site.