### PR TITLE
More efficient cache purge 

### DIFF
--- a/src/Test/WordPress/UtilsTest.php
+++ b/src/Test/WordPress/UtilsTest.php
@@ -10,15 +10,15 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
     {
     }
 
-    public function testEndsWith()
+    public function testStrEndsWith()
     {
-        $this->assertFalse(Utils::endsWith('abcdef', 'ab'));
-        $this->assertFalse(Utils::endsWith('abcdef', 'cd'));
-        $this->assertTrue(Utils::endsWith('abcdef', 'ef'));
-        $this->assertTrue(Utils::endsWith('abcdef', 'abcdef'));
-        $this->assertTrue(Utils::endsWith('abcdef', ''));
-        $this->assertFalse(Utils::endsWith('', 'abcdef'));
-        $this->assertTrue(Utils::endsWith('', ''));
+        $this->assertFalse(Utils::strEndsWith('abcdef', 'ab'));
+        $this->assertFalse(Utils::strEndsWith('abcdef', 'cd'));
+        $this->assertTrue(Utils::strEndsWith('abcdef', 'ef'));
+        $this->assertTrue(Utils::strEndsWith('abcdef', 'abcdef'));
+        $this->assertFalse(Utils::strEndsWith('abcdef', ''));
+        $this->assertFalse(Utils::strEndsWith('', 'abcdef'));
+        $this->assertFalse(Utils::strEndsWith('', ''));
     }
 
     public function testIsSubdomainOf()

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -141,6 +141,11 @@ class Hooks
                 return;
             }
 
+            $postType = get_post_type_object(get_post_type($postId));
+            if (!$postType->public || !$postType->publicly_queryable) {
+                return;
+            }
+
             $savedPost = get_post($postId);
             if (!is_a($savedPost, 'WP_Post')) {
                 return;

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -156,6 +156,13 @@ class Hooks
 
             $zoneTag = $this->api->getZoneTag($wpDomain);
 
+            // Don't attempt to purge anything outside of the provided zone.
+            foreach ($urls as $key => $url) {
+                if (parse_url($url, PHP_URL_HOST) !== $wpDomain) {
+                    unset($urls[$key]);
+                }
+            }
+
             if (isset($zoneTag) && !empty($urls)) {
                 $chunks = array_chunk($urls, 30);
 

--- a/src/WordPress/Utils.php
+++ b/src/WordPress/Utils.php
@@ -12,9 +12,13 @@ class Utils
      *
      * @return bool
      */
-    public static function endsWith($haystack, $needle)
+    public static function strEndsWith($haystack, $needle)
     {
-        return $needle === '' || (($temp = strlen($haystack) - strlen($needle)) >= 0 && strpos($haystack, $needle, $temp) !== false);
+        if (empty($haystack) || empty($needle)) {
+            return false;
+        }
+        $needle_len = strlen($needle);
+        return ($needle_len === 0 || 0 === substr_compare($haystack, $needle, -$needle_len));
     }
 
     public static function isSubdomainOf($subDomainName, $domainName)
@@ -29,9 +33,9 @@ class Utils
             return false;
         }
 
-        return self::endsWith($subDomainName, $domainName) &&
-                $subDomainName !== $domainName &&
-                $subDomainName[$dotPosition] == '.';
+        return self::strEndsWith($subDomainName, $domainName) &&
+            $subDomainName !== $domainName &&
+            $subDomainName[$dotPosition] == '.';
     }
 
     public static function getRegistrableDomain($domainName)

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -17,7 +17,7 @@ class WordPressClientAPI extends Client
     {
         $zone_name = idn_to_ascii($zone_name, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
 
-        $zone_tag = wp_cache_get('cloudflare/client-api/zone-tag/'.$zone_name);
+        $zone_tag = wp_cache_get('cloudflare/client-api/zone-tag/' . $zone_name);
         if (false !== $zone_tag) {
             return $zone_tag;
         }
@@ -35,7 +35,7 @@ class WordPressClientAPI extends Client
             }
         }
 
-        wp_cache_set('cloudflare/client-api/zone-tag/'.$zone_name, $zone_tag);
+        wp_cache_set('cloudflare/client-api/zone-tag/' . $zone_name, $zone_tag);
 
         return $zone_tag;
     }
@@ -47,7 +47,7 @@ class WordPressClientAPI extends Client
      */
     public function zonePurgeCache($zoneId)
     {
-        $request = new Request('DELETE', 'zones/'.$zoneId.'/purge_cache', array(), array('purge_everything' => true));
+        $request = new Request('DELETE', 'zones/' . $zoneId . '/purge_cache', array(), array('purge_everything' => true));
         $response = $this->callAPI($request);
 
         return $this->responseOk($response);
@@ -61,7 +61,7 @@ class WordPressClientAPI extends Client
      */
     public function zonePurgeFiles($zoneId, $files)
     {
-        $request = new Request('DELETE', 'zones/'.$zoneId.'/purge_cache', array(), array('files' => $files));
+        $request = new Request('DELETE', 'zones/' . $zoneId . '/purge_cache', array(), array('files' => $files));
         $response = $this->callAPI($request);
 
         return $this->responseOk($response);
@@ -76,7 +76,7 @@ class WordPressClientAPI extends Client
      */
     public function changeZoneSettings($zoneId, $settingName, $params)
     {
-        $request = new Request('PATCH', 'zones/'.$zoneId.'/settings/'.$settingName, array(), $params);
+        $request = new Request('PATCH', 'zones/' . $zoneId . '/settings/' . $settingName, array(), $params);
         $response = $this->callAPI($request);
 
         return $this->responseOk($response);
@@ -89,7 +89,7 @@ class WordPressClientAPI extends Client
      */
     public function createPageRule($zoneId, $body)
     {
-        $request = new Request('POST', 'zones/'.$zoneId.'/pagerules/', array(), $body);
+        $request = new Request('POST', 'zones/' . $zoneId . '/pagerules/', array(), $body);
         $response = $this->callAPI($request);
 
         return $this->responseOk($response);
@@ -128,7 +128,7 @@ class WordPressClientAPI extends Client
         }
 
         // Construct URL
-        $url = add_query_arg($request->getParameters(), $this->getEndpoint().$request->getUrl());
+        $url = add_query_arg($request->getParameters(), $this->getEndpoint() . $request->getUrl());
 
         // Send Request
         $requestResponse = wp_remote_request($url, $requestParams);

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -96,6 +96,25 @@ class WordPressClientAPI extends Client
     }
 
     /**
+     * Returns all page rules in the desired state. Defaults to active.
+     *
+     * @param mixed $zoneId
+     * @param string $status
+     * @return array
+     */
+    public function getPageRules($zoneId, $status = "active")
+    {
+        $request = new Request('GET', 'zones/' . $zoneId . "/pagerules?status=$status", array(), null);
+        $response = $this->callAPI($request);
+
+        if ($this->responseOk($response)) {
+            return $response["result"];
+        }
+
+        return [];
+    }
+
+    /**
      * @param Request $request
      *
      * @return array|mixed


### PR DESCRIPTION
This PR focuses on improving the accuracy and number of URLs that we end up 
sending to the cache purge service. Included are three improvements:

**Don't attempt to purge URLs outside of the current zone**

Cache purge requests are tied to credentials and if those credentials don't 
match the current zone, the URL is thrown away. 

**Don't purge non-public facing posts** 

Many systems have a concept of "public facing" content; this is content that is 
designed for end users. Previously, we didn't take into account things like 
backend URLs, posts that were private and content that wouldn't ever be in the 
caches. With this change, we'll rely on the WordPress context to determine if
the content is publicly queryable and subsequently, purgable.

**Only purge cachable file extensions unless we find hints in page rules or APO 
is enabled**

By default, caching within Cloudflare is restricted to a handful of file
[extensions][1]. However, within the plugin, we just pass it all the
cache purge irrespective of the file extension or zone configuration. This
means we're sending a boat load more URLs to the service than what we will
never be purging.

To combat this we are introducing some additional logic that checks two things:

Firstly, we look at the page rules for the presence of any cache override 
behaviour should it not be present, filter the URLs to only purge those in the 
default caching extensions. This should be considered quite safe as out of the 
box, everyone starts with this configuration and is only overridden when someone 
explicitly sets this in page rules. We don't bother reimplementing the page rule 
globbing logic but instead just check for the presence of "cache_everything" 
for the cache level in any rule.

Secondly, we ensure the zone doesn't have APO enabled. APO is a feature that 
relies on custom purge logic we don't want to duplicate here so just skip it if 
it exists.

To provide a more visual overview, here is a quick diagram of the flow with 
these proposed updates.

```
┌─────────────────────┐
│    purge request    │
│      initiated      │
└─────────────────────┘
           │
           │
           ▼
┌─────────────────────┐
│ post is auto saved  │
│  or post revision?  │───yes───▶ do nothing, exit
└─────────────────────┘
           │
          no
           │
           ▼
┌─────────────────────┐
│   post is public?   │────no───▶ do nothing, exit
└─────────────────────┘
           │
          yes
           │
           │
           ▼
┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
    runs cloudflare_purge_by_url hook
└ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
           │
           │
           ▼
┌─────────────────────────────────────────────┐
│  zone has cache_level = "cache_everything"  │
│     page rule present OR is using APO?      │
└─────┬─────────┬─────────────────────────────┘
      │         │
      │         │
      │         │
      │         │    ┌────────────────────────┐
      │         │    │  remove any URLs that  │
      │         │    │         don't          │
      │         └───▶│  have a cachable file  │
      │              │       extension        │
      │              └────────────────────────┘
      │                           │
      │                           │
      │      ┌────────────────────┘
      │      │
      ▼      ▼
 ┌──────────────────────────┐         ┌──────────────┐
 │URL matches current zone? │───no───▶│ discard URL  │
 └──────────────────────────┘         └──────────────┘
               │
              yes
               │
               ▼
 ┌──────────────────────────┐
 │    purge request sent    │
 └──────────────────────────┘
```

Worth noting as well, these restrictions **do not apply** to the UI 
where you can provide URLs (that is separate to this).

![hvi1Cy62-NpJ37sJD-i6CGv0Ao](https://user-images.githubusercontent.com/283234/158083444-2676738d-3d87-46f4-a31e-c7e37fbf12fb.png)


Closes #448
Closes #429

[1]: https://developers.cloudflare.com/cache/about/default-cache-behavior/#default-cached-file-extensions