### PR TITLE
relax cache purge domain check

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -176,7 +176,7 @@ class Hooks
 
             // Don't attempt to purge anything outside of the provided zone.
             foreach ($urls as $key => $url) {
-                if (parse_url($url, PHP_URL_HOST) !== $wpDomain) {
+                if (!Utils::strEndsWith(parse_url($url, PHP_URL_HOST), $wpDomain)) {
                     unset($urls[$key]);
                 }
             }


### PR DESCRIPTION
Updates the filtering to allow using subdomains within WordPress. Other
parts of the code ignore subdomains entirely but this was incorrectly
doing a strict comparison.