### PR TITLE
if `always_use_https` enabled, only purge HTTPS URLs

### DIFF
--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -83,6 +83,21 @@ class WordPressClientAPI extends Client
     }
 
     /**
+     * @param $zoneId
+     * @param $settingName
+     * @param $params
+     *
+     * @return bool
+     */
+    public function getZoneSetting($zoneId, $settingName)
+    {
+        $request = new Request('GET', 'zones/' . $zoneId . '/settings/' . $settingName, array(), null);
+        $response = $this->callAPI($request);
+
+        return $response["result"];
+    }
+
+    /**
      * @param $urlPattern
      *
      * @return array


### PR DESCRIPTION
In a bid to further reduce the number of URLs we send to the cache purge
service, we can check if the zone has "always_use_https" enabled
(without a page rule override) and should it, remove any HTTP URLs as
they won't be getting hit in cache.