### PR TITLE
add scripts/bump-plugin-version.sh

### DIFF
--- a/docs/release-new-version.md
+++ b/docs/release-new-version.md
@@ -8,8 +8,12 @@ projects, update them and commit the changes.
 ### Update readme.txt and plugin version references
 
 WordPress uses the readme.txt heavily for metadata about the plugin. You will
-need to bump the version number and update `== Changelog ==` section according
-to what code changes have been made since the last release.
+need to update `== Changelog ==` section according to what code changes have
+been made since the last release.
+
+To bump all the places where the plugin version is defined, run
+`scripts/bump-plugin-version.sh x.x.x` (replacing x.x.x) with your proposed
+version number.
 
 ## Prepare to release
 

--- a/scripts/bump-plugin-version.sh
+++ b/scripts/bump-plugin-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "VERSION not provided."
+    exit 1
+fi
+
+VERSION=$1
+
+echo "Preparing release: $VERSION"
+
+echo "==> Updating config.json..."
+# config.json
+NEW_CONFIG_JSON=$(cat config.json | jq ".version |= \"$VERSION\""); echo $NEW_CONFIG_JSON | jq . > config.json
+echo "==> Complete ✅"
+
+echo "==> Updating composer.json..."
+# composer.json
+NEW_COMPOSER_JSON=$(cat composer.json | jq ".version |= \"$VERSION\""); echo $NEW_COMPOSER_JSON | jq . > composer.json
+echo "==> Complete ✅"
+
+echo "==> Updating readme.txt..."
+# readme.txt
+sed -i '' "s/Stable tag:.*/Stable tag: $VERSION/g" readme.txt
+echo "==> Complete ✅"
+
+echo "==> Updating cloudflare.php..."
+# cloudflare.php
+sed -i '' "s/Version:.*/Version: $VERSION/g" cloudflare.php
+echo "==> Complete ✅"
+echo
+echo "Release preparation complete! Don't forget to:"
+echo "- Add a CHANGELOG entry to readme.txt"
+echo "- \`composer update --no-dev\` to update the content-hash attribute"
+echo "- Commit all the changes and push!"


### PR DESCRIPTION
Introduce a script that handles bumping all the places we define the
plugin version so we don't forget and cause misinformation in the user
agent being sent.