### PR TITLE
Fix for APO not purging cache on page save

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -152,7 +152,7 @@ class Hooks
             }
 
             $postType = get_post_type_object(get_post_type($postId));
-            if (!$postType->public || !$postType->publicly_queryable) {
+            if (!is_post_type_viewable($postType)) {
                 return;
             }
 


### PR DESCRIPTION
Saving changes on a page was not triggering cache purge for that page. Condition for testing used check for publicly_queryable prop, which by default return false for pages. However WP has build-in function for checking if queried object can be publicly viewed and returns correct values for all types of posts.