### PR TITLE
Allow clearing cache for array of post ids or single post id

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -164,7 +164,7 @@ class Hooks
                     continue;
                 }
 
-                $urls = array_values(array_unique(array_merge($urls, $this->getPostRelatedLinks($postId))));
+                $urls = array_merge($urls, $this->getPostRelatedLinks($postId));
                 $urls = apply_filters('cloudflare_purge_by_url', $urls, $postId);
             }
             $urls = apply_filters('cloudflare_purge_by_urls', $urls, $postIds);
@@ -346,7 +346,7 @@ class Hooks
         }
 
         // Clean array if row empty
-        $listofurls = array_filter($listofurls);
+        $listofurls = array_values(array_unique(array_filter($listofurls)));
 
         return $listofurls;
     }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -173,6 +173,9 @@ class Hooks
                 return;
             }
 
+            // Filter by unique urls
+            $urls = array_values(array_unique($urls));
+
             $zoneTag = $this->api->getZoneTag($wpDomain);
             $activePageRules = $this->api->getPageRules($zoneTag, "active");
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -203,7 +203,7 @@ class Hooks
             }
 
             if (!empty($urls)) {
-                do_action('cloudflare_purge_by_urls', $urls, $postIds);
+                do_action('cloudflare_purged_urls', $urls, $postIds);
                 $chunks = array_chunk($urls, 30);
 
                 foreach ($chunks as $chunk) {

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -169,12 +169,12 @@ class Hooks
             }
             $urls = apply_filters('cloudflare_purge_by_urls', $urls, $postIds);
 
-            if (empty($urls)) {
+            if (!is_array($urls) || empty($urls)) {
                 return;
             }
 
             // Filter by unique urls
-            $urls = array_values(array_unique($urls));
+            $urls = array_values(array_filter(array_unique($urls)));
 
             $zoneTag = $this->api->getZoneTag($wpDomain);
             $activePageRules = $this->api->getPageRules($zoneTag, "active");

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -171,7 +171,6 @@ class Hooks
                 $urls = array_values(array_unique(array_merge($urls, $this->getPostRelatedLinks($postId))));
                 $urls = apply_filters('cloudflare_purge_by_url', $urls, $postId);
             }
-            $urls = apply_filters('cloudflare_purge_by_urls', $urls, $postIds);
 
             // Don't attempt to purge anything outside of the provided zone.
             foreach ($urls as $key => $url) {
@@ -204,6 +203,7 @@ class Hooks
             }
 
             if (!empty($urls)) {
+                do_action('cloudflare_purge_by_urls', $urls, $postIds);
                 $chunks = array_chunk($urls, 30);
 
                 foreach ($chunks as $chunk) {

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -168,8 +168,8 @@ class Hooks
                     continue;
                 }
 
-                $urls = array_values(array_unique(array_merge($urls, $this->getPostRelatedLinks($postId))));
-                $urls = apply_filters('cloudflare_purge_by_url', $urls, $postId);
+                $relatedUrls = apply_filters('cloudflare_purge_by_url', $this->getPostRelatedLinks($postId), $postId);
+                $urls = array_merge($urls, $relatedUrls);
             }
 
             // Don't attempt to purge anything outside of the provided zone.

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -346,7 +346,7 @@ class Hooks
         }
 
         // Clean array if row empty
-        $listofurls = array_values(array_unique(array_filter($listofurls)));
+        $listofurls = array_values(array_filter(array_unique($listofurls)));
 
         return $listofurls;
     }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -164,7 +164,7 @@ class Hooks
                     continue;
                 }
 
-                $urls = array_merge($urls, $this->getPostRelatedLinks($postId));
+                $urls = array_values(array_unique(array_merge($urls, $this->getPostRelatedLinks($postId))));
                 $urls = apply_filters('cloudflare_purge_by_url', $urls, $postId);
             }
             $urls = apply_filters('cloudflare_purge_by_urls', $urls, $postIds);
@@ -334,9 +334,12 @@ class Hooks
             }
             $listofurls = array_merge(
                 $listofurls,
-                array_unique(array_filter($attachmentUrls))
+                $attachmentUrls
             );
         }
+
+        // Clean array and get unique values
+        $listofurls = array_values(array_filter(array_unique($listofurls)));
 
         // Purge https and http URLs
         if (function_exists('force_ssl_admin') && force_ssl_admin()) {
@@ -344,9 +347,6 @@ class Hooks
         } elseif (!is_ssl() && function_exists('force_ssl_content') && force_ssl_content()) {
             $listofurls = array_merge($listofurls, str_replace('http://', 'https://', $listofurls));
         }
-
-        // Clean array if row empty
-        $listofurls = array_values(array_filter(array_unique($listofurls)));
 
         return $listofurls;
     }


### PR DESCRIPTION
I have a use case that would have required many extraneous requests to clear related urls from the cache.

Use case: Woocommerce coupon is updated. Products that are valid for this coupon and their related links need to be cleared from cache.

Problem: Cloudflare module allows me to clear related links based on a single post id.  In my case, there is significant overlap between the related posts.  Causes many extra requests to clear urls.

Solution: Allow for either a postId or postIds array to be process by Hooks purgeCacheByRelevantURLs.  Aggregate all related links and apply array_unique to only clear overlapping urls once.

Results:
![image](https://user-images.githubusercontent.com/6331501/165136791-a5151dd2-40da-4f0d-a18e-3775b3732744.png)

For 24 products (posts) that need their related links cleared, pull request reduces the amount of API requests from 31 to 7 (442% decrease) and the amount of individuals chunked urls that need to be cleared from 902 to 192.  This is for a forced https site, non forced https sites would double that amount.
