### PR TITLE
Feature clearterms

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -117,3 +117,8 @@ add_action('transition_post_status', array($cloudflareHooks, 'purgeCacheOnPostSt
  */
 add_action('transition_comment_status', array($cloudflareHooks, 'purgeCacheOnCommentStatusChange'), PHP_INT_MAX, 3);
 add_action('comment_post', array($cloudflareHooks, 'purgeCacheOnNewComment'), PHP_INT_MAX, 3);
+
+/**
+ * Register an action which accounts for taxonomy term (category or tag) changes
+ */
+add_action('clean_term_cache', array($cloudflareHooks, 'purgeCacheOnTermChange'), PHP_INT_MAX, 3);

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -6,6 +6,7 @@ use CF\API\APIInterface;
 use CF\Integration;
 use Psr\Log\LoggerInterface;
 use WP_Taxonomy;
+use WP_Query;
 
 class Hooks
 {
@@ -483,7 +484,7 @@ class Hooks
             )
         );
 
-        $query = new \WP_Query($args);
+        $query = new WP_Query($args);
         if (!empty($query->posts)) {
             $this->purgeCacheByRelevantURLs($query->posts);
         }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -155,12 +155,7 @@ class Hooks
             $urls = [];
             foreach ($postIds as $postId) {
                 // Do not purge for autosaves or updates to post revisions.
-                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId) || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
-                    continue;
-                }
-
-                // Do no purge for non-published posts (auto-draft, draft)
-                if (get_post_status($postId) !== 'publish') {
+                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId)) {
                     continue;
                 }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -155,7 +155,12 @@ class Hooks
             $urls = [];
             foreach ($postIds as $postId) {
                 // Do not purge for autosaves or updates to post revisions.
-                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId)) {
+                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId) || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
+                    continue;
+                }
+
+                // Do no purge for non-published posts (auto-draft, draft)
+                if (get_post_status($postId) !== 'publish') {
                     continue;
                 }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -464,6 +464,31 @@ class Hooks
         $this->purgeCacheByRelevantURLs($comment_data['comment_post_ID']);
     }
 
+    public function purgeCacheOnTermChange($ids, $taxonomy, $clean_taxonomy)
+    {
+        $args = array(
+            'posts_per_page' => -1,
+            'post_status' => 'publish',
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'update_post_term_cache' => false,
+            'update_post_meta_cache' => false,
+            'tax_query' => array(
+                array(
+                    'taxonomy' => $taxonomy,
+                    'field' => 'term_id',
+                    'terms' => $ids,
+                    'operator' => 'IN'
+                )
+            )
+        );
+
+        $query = new \WP_Query($args);
+        if (!empty($query->posts)) {
+            $this->purgeCacheByRelevantURLs($query->posts);
+        }
+    }
+
     /**
      * Accepts a page rule key and value to check if it exists in the page rules
      * provided.


### PR DESCRIPTION
Clears related posts when a taxonomy term changes (when WP is calling for clean_term_cache)