### PR TITLE
Restrict access

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,5 +1,7 @@
 /.git
 /.github
+/.vscode
+/xdebug
 /scripts
 /docs
 
@@ -9,5 +11,6 @@
 CONTRIBUTING.md
 docker-compose.yaml
 Dockerfile.wordpress
+docker_tag
 phpcs.xml
 phpunit.xml

--- a/.htaccess
+++ b/.htaccess
@@ -41,7 +41,7 @@
 </FilesMatch>
 
 # Cloudflare fonts
-<FilesMatch "^.+(eot|ttf||otf|woff|woff2 )$">
+<FilesMatch "^.+(eot|ttf||otf|woff|woff2)$">
         # Apache 2.2
         <IfModule !mod_authz_core.c>
                 Allow from all

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,54 @@
+# Restricts direct access to files that are not intended to be publicly available
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+        Order Deny,Allow
+        Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+        Require all denied
+</IfModule>
+
+
+# Allows direct access to specific files only
+
+# Cloudflare JS and CSS
+<FilesMatch "^.+(js|css)$">
+        # Apache 2.2
+        <IfModule !mod_authz_core.c>
+                Allow from all
+        </IfModule>
+
+        # Apache 2.4
+        <IfModule mod_authz_core.c>
+                Require all granted
+        </IfModule>
+</FilesMatch>
+
+# Cloudflare images
+<FilesMatch "^.+(png|svg|gif|jpg|webp)$">
+        # Apache 2.2
+        <IfModule !mod_authz_core.c>
+                Allow from all
+        </IfModule>
+
+        # Apache 2.4
+        <IfModule mod_authz_core.c>
+                Require all granted
+        </IfModule>
+</FilesMatch>
+
+# Cloudflare fonts
+<FilesMatch "^.+(eot|ttf||otf|woff|woff2 )$">
+        # Apache 2.2
+        <IfModule !mod_authz_core.c>
+                Allow from all
+        </IfModule>
+
+        # Apache 2.4
+        <IfModule mod_authz_core.c>
+                Require all granted
+        </IfModule>
+</FilesMatch>


### PR DESCRIPTION
After installation, this plugin creates a file called output.log which is publicly accessible if the web server is not explicitly configured to block direct access to this type of file.

Consequently I have added a file called .htaccess which, for users using Apache web server, allows direct public access only to images, fonts, js and css files specific to this plugin.

So it restricts direct public access to files like config.json, output.log, readme.txt, LICENSE.md, etc.

This is a similar configuration to that used by Akismet in their open source plugin. See details here: https://github.com/wp-plugins/akismet/blob/master/.htaccess


In addition I added the docker_tag file and the xdebug and .vscode folders to the list of files and folders that are ignored when creating a new package that is distributed on WordPress.org.

@jacobbednarz when you have the necessary free time, please kindly review my changes.