### PR TITLE
Clear related on wp clean_post and clean_attachment

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use CloudFlare\IpRewrite;
 
@@ -55,10 +55,10 @@ if (is_admin()) {
     add_action('plugin_action_links_cloudflare/cloudflare.php', array($cloudflareHooks, 'pluginActionLinks'));
 
     // Load Activation Script
-    register_activation_hook(CLOUDFLARE_PLUGIN_DIR.'cloudflare.php', array($cloudflareHooks, 'activate'));
+    register_activation_hook(CLOUDFLARE_PLUGIN_DIR . 'cloudflare.php', array($cloudflareHooks, 'activate'));
 
     // Load Deactivation Script
-    register_deactivation_hook(CLOUDFLARE_PLUGIN_DIR.'cloudflare.php', array($cloudflareHooks, 'deactivate'));
+    register_deactivation_hook(CLOUDFLARE_PLUGIN_DIR . 'cloudflare.php', array($cloudflareHooks, 'deactivate'));
 }
 
 // Load Automatic Cache Purge
@@ -93,8 +93,8 @@ foreach ($cloudflarePurgeEverythingActions as $action) {
  */
 
 $cloudflarePurgeURLActions = array(
-    'deleted_post',                     // Delete a post
-    'delete_attachment',                // Delete an attachment - includes re-uploading
+    'clean_post_cache', // https://developer.wordpress.org/reference/functions/clean_post_cache/
+    'clean_attachment_cache', // https://developer.wordpress.org/reference/functions/clean_attachment_cache/
 );
 
 $cloudflarePurgeURLActions = apply_filters('cloudflare_purge_url_actions', $cloudflarePurgeURLActions);

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -154,7 +154,7 @@ class Hooks
             $urls = [];
             foreach ($postIds as $postId) {
                 // Do not purge for autosaves or updates to post revisions.
-                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId)) {
+                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId) || get_post_status($postId) === 'auto-draft') {
                     continue;
                 }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -154,12 +154,7 @@ class Hooks
             $urls = [];
             foreach ($postIds as $postId) {
                 // Do not purge for autosaves or updates to post revisions.
-                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId) || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
-                    continue;
-                }
-
-                // Do no purge for non-published posts (auto-draft, draft)
-                if (get_post_status($postId) !== 'publish') {
+                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId)) {
                     continue;
                 }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -154,7 +154,12 @@ class Hooks
             $urls = [];
             foreach ($postIds as $postId) {
                 // Do not purge for autosaves or updates to post revisions.
-                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId) || get_post_status($postId) === 'auto-draft') {
+                if (wp_is_post_autosave($postId) || wp_is_post_revision($postId) || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
+                    continue;
+                }
+
+                // Do no purge for non-published posts (auto-draft, draft)
+                if (get_post_status($postId) !== 'publish') {
                     continue;
                 }
 


### PR DESCRIPTION
Piggybacks wordpress built in cache clearing functions to decide when to clear related urls.  Works on a handful of additional changes not currently monitored by existing "delete_post" and "delete_attachment" hooks, but includes them as well.

https://developer.wordpress.org/reference/functions/clean_post_cache/#:~:text=do_action(%20%27clean_page_cache%27%2C%20%24post%2D%3EID%20)%3B

https://developer.wordpress.org/reference/functions/clean_post_cache/#:~:text=Used%20By-,Used%20By,-Description


https://developer.wordpress.org/reference/functions/clean_attachment_cache/#:~:text=do_action(%20%27clean_attachment_cache%27%2C%20%24id%20)%3B

https://developer.wordpress.org/reference/functions/clean_attachment_cache/#:~:text=Used%20By-,Used%20By,-Description