### PR TITLE
Add filter to allow developers to determine cache usage

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -421,7 +421,8 @@ class Hooks
         }
 
         // add header unconditionally so we can detect plugin is activated
-        if (!is_user_logged_in()) {
+        $cache = apply_filters('cloudflare_use_cache', !is_user_logged_in());
+        if ($cache) {
             header('cf-edge-cache: cache,platform=wordpress');
         } else {
             header('cf-edge-cache: no-cache');


### PR DESCRIPTION
Use case: Woocommerce customers with role customer should also be served cached pages from cloudflare.  Added a hook to allow the cache state boolean to be manipulated.