### PR TITLE
fix logic for skipping purging unnecessary feed urls

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -194,7 +194,7 @@ class Hooks
             // default.
             if (!$hasCacheOverride) {
                 $this->logger->debug("cache everything behaviour found, filtering out feeds URLs");
-                $urls = array_filter($urls, array($this, "pathIsForFeeds"));
+                $urls = array_filter($urls, array($this, "pathIsNotForFeeds"));
             }
 
             // Fetch the page rules and should we not have any hints of cache
@@ -538,7 +538,7 @@ class Hooks
     }
 
     /**
-     * pathIsForFeeds accepts a string URL and checks if the path matches any
+     * pathIsNotForFeeds accepts a string URL and checks if the path doesn't matches any
      * known feed paths such as "/feed", "/feed/", "/feed/rdf/", "/feed/rss/",
      * "/feed/atom/", "/author/foo/feed", "/comments/feed", "/shop/feed",
      * "/tag/.../feed/", etc.
@@ -546,10 +546,10 @@ class Hooks
      * @param mixed $value
      * @return bool
      */
-    private function pathIsForFeeds($value)
+    private function pathIsNotForFeeds($value)
     {
         $parsed_url = parse_url($value, PHP_URL_PATH);
-        return (bool) preg_match('/\/feed(?:\/(?:atom\/?|r(?:df|ss)\/?)?)?$/', $parsed_url);
+        return (bool) !preg_match('/\/feed(?:\/(?:atom\/?|r(?:df|ss)\/?)?)?$/', $parsed_url);
     }
 
     /**


### PR DESCRIPTION
current logic filters out NON feed urls:

<img width="896" alt="Screen Shot 2022-06-05 at 3 42 12 PM" src="https://user-images.githubusercontent.com/43054535/172067714-f4722006-51bd-4c45-9788-8b2acd0c8819.png">

while we want to filter out unnecessary feed urls and keep everything else:

<img width="896" alt="Screen Shot 2022-06-05 at 3 41 15 PM" src="https://user-images.githubusercontent.com/43054535/172067691-632fd88b-14fd-4de9-9430-4d81447989ae.png">


This fixes the issue reported in https://github.com/cloudflare/Cloudflare-WordPress/issues/484