### PR TITLE
Updates purgeCacheByRelevantURLs filter to allow arrays

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -174,7 +174,11 @@ class Hooks
 
             // Don't attempt to purge anything outside of the provided zone.
             foreach ($urls as $key => $url) {
-                $url_to_test = is_array($url) ? $url['url'] : $url;
+                $url_to_test = $url;
+                if(is_array($url) && !!$url['url'] ){
+                    $url_to_test = $url['url'];
+                }
+
                 if (!Utils::strEndsWith(parse_url($url_to_test, PHP_URL_HOST), $wpDomain)) {
                     unset($urls[$key]);
                 }

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -175,7 +175,7 @@ class Hooks
             // Don't attempt to purge anything outside of the provided zone.
             foreach ($urls as $key => $url) {
                 $url_to_test = $url;
-                if(is_array($url) && !!$url['url'] ){
+                if (is_array($url) && !!$url['url']) {
                     $url_to_test = $url['url'];
                 }
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -174,7 +174,8 @@ class Hooks
 
             // Don't attempt to purge anything outside of the provided zone.
             foreach ($urls as $key => $url) {
-                if (!Utils::strEndsWith(parse_url($url, PHP_URL_HOST), $wpDomain)) {
+                $url_to_test = is_array($url) ? $url['url'] : $url;
+                if (!Utils::strEndsWith(parse_url($url_to_test, PHP_URL_HOST), $wpDomain)) {
                     unset($urls[$key]);
                 }
             }


### PR DESCRIPTION
Closes #488 

This PR should fix the issue where the cache for a URL won't get purged if it's defined as an array, for example if there are headers .
