### PR TITLE
Ensure that getZoneSetting() returns a value key before attempting to access it

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -519,7 +519,7 @@ class Hooks
     private function zoneSettingAlwaysUseHTTPSEnabled($zoneTag)
     {
         $settings = $this->api->getZoneSetting($zoneTag, "always_use_https");
-        return $settings && isset($settings["value"]) && $settings["value"] == "on";
+        return !empty($settings["value"]) && $settings["value"] == "on";
     }
 
 

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -519,7 +519,7 @@ class Hooks
     private function zoneSettingAlwaysUseHTTPSEnabled($zoneTag)
     {
         $settings = $this->api->getZoneSetting($zoneTag, "always_use_https");
-        return $settings["value"] == "on";
+        return $settings && isset($settings["value"]) && $settings["value"] == "on";
     }
 
 


### PR DESCRIPTION
I received this error on my site:

> Trying to access array offset on value of type null

Because `CF\WordPress\Hooks::zoneSettingAlwaysUseHTTPSEnabled()` got back a null from `$this->api->getZoneSetting($zoneTag, "always_use_https")` and then tried to access `["value"]` on that null.

This adds some sanity checks on the value. Note that this will default the return value to `false` if the zone setting comes back as null — I think that's a reasonable assumption.

Using older PHP syntax for this check to retain maximum compatibility (WordPress unfortunately still runs on PHP 5.6).