### PR TITLE
moved cloudflare.loader.php loader into the init action

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -46,4 +46,6 @@ if (version_compare(PHP_VERSION, CLOUDFLARE_MIN_PHP_VERSION, '<')) {
 
 // Plugin uses namespaces. To support old PHP version which doesn't support
 // namespaces we load everything in "cloudflare.loader.php"
-require_once CLOUDFLARE_PLUGIN_DIR . 'cloudflare.loader.php';
+add_action('init', function () {
+    require_once CLOUDFLARE_PLUGIN_DIR . 'cloudflare.loader.php';
+});


### PR DESCRIPTION
Moved cloudflare.loader.php loader into the init action so the cloudflare_purge_everything_actions can be run from the theme.

As it is now that filter has already run before you have a chance to use it.