### PR TITLE
Feature purge on cron

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -43,9 +43,7 @@ if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PU
 }
 
 add_action('init', array($cloudflareHooks, 'initAutomaticPlatformOptimization'));
-if (apply_filters('cloudflare_purge_on_cron', false)) {
-    add_action('init', array($cloudflareHooks, 'initCronScheduleQueuePurge'));
-}
+add_action('init', array($cloudflareHooks, 'initCronScheduleQueuePurge'));
 
 if (is_admin()) {
     //Register proxy AJAX endpoint

--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -43,7 +43,9 @@ if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PU
 }
 
 add_action('init', array($cloudflareHooks, 'initAutomaticPlatformOptimization'));
-add_action('init', array($cloudflareHooks, 'initScheduleQueuePurge'));
+if (apply_filters('cloudflare_purge_on_cron', false)) {
+    add_action('init', array($cloudflareHooks, 'initCronScheduleQueuePurge'));
+}
 
 if (is_admin()) {
     //Register proxy AJAX endpoint

--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -43,6 +43,7 @@ if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PU
 }
 
 add_action('init', array($cloudflareHooks, 'initAutomaticPlatformOptimization'));
+add_action('init', array($cloudflareHooks, 'initScheduleQueuePurge'));
 
 if (is_admin()) {
     //Register proxy AJAX endpoint

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -137,7 +137,7 @@ class Hooks
         }
     }
 
-    public function initScheduleQueuePurge()
+    public function initCronScheduleQueuePurge()
     {
         // Add a new interval for cron purge
         add_filter('cron_schedules', function ($schedules) {
@@ -157,7 +157,7 @@ class Hooks
         add_action('cloudflare_cron_purge_queue', array($this, 'cronPurgeQueue'));
     }
 
-    public function queuePostIdPurge($postIds)
+    public function cronQueuePostIdPurge($postIds)
     {
         $queued = get_option('cloudflare_related_urls', []);
         foreach ($postIds as $postId) {
@@ -198,7 +198,11 @@ class Hooks
 
     public function purgeCacheByRelevantURLs($postIds)
     {
-        return $this->queuePostIdPurge((array) $postIds);
+        if (apply_filters('cloudflare_purge_on_cron', false)) {
+            return $this->cronQueuePostIdPurge((array) $postIds);
+        } else {
+            return $this->purgeCacheByPostIds($postIds);
+        }
     }
 
     public function purgeCacheByPostIds($postIds)


### PR DESCRIPTION
With the limitations and long run time of clearing related urls, and given the delay of clearing the edge caches,  I've added the ability to purge aggregated entries on cron

By default, the existing behavior is maintained if the 'cloudflare_purge_on_cron' is not returning true