### PR TITLE
Purge cache on tablet fixes #500

### DIFF
--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -234,10 +234,25 @@ class Hooks
                         $isOK = ($isOK) ? 'succeeded' : 'failed';
                         $this->logger->debug("List of URLs purged on mobile are: " . print_r($chunk, true));
                         $this->logger->debug("purgeCacheByRelevantURLs " . $isOK);
+
+                        $isOK = $this->api->zonePurgeFiles($zoneTag, array_map(array($this, 'toPurgeCacheOnTablet'), $chunk));
+
+                        $isOK = ($isOK) ? 'succeeded' : 'failed';
+                        $this->logger->debug("List of URLs purged on tablet are: " . print_r($chunk, true));
+                        $this->logger->debug("purgeCacheByRelevantURLs " . $isOK);
                     }
                 }
             }
         }
+    }
+
+    protected function toPurgeCacheOnTablet($url)
+    {
+        //Purge cache on tablet
+        $headers = array("CF-Device-Type" => "tablet");
+        $purge_object = array("url" => $url, "headers" => $headers);
+        $json = json_decode(json_encode($purge_object, JSON_FORCE_OBJECT));
+        return $json;
     }
 
     protected function toPurgeCacheOnMobile($url)


### PR DESCRIPTION
If cache by device type is enabled the plugin currently only purges the desktop and mobile cache, this introduces a fix to purge tablet alongside mobile.

As described in #500 the cache isn't purged right now for tablet.

I don't think this fix is ideal as it means 3 requests per URL need to go to Cloudflare to per the cache, it would be nice if we could pass an array for `CF-Device-Type` or if the API allowed purging of all caches together.
