### PR TITLE
Fix "creation of dynamic property is deprecated" notice

### DIFF
--- a/src/WordPress/DataStore.php
+++ b/src/WordPress/DataStore.php
@@ -14,6 +14,7 @@ class DataStore implements DataStoreInterface
     const CACHED_DOMAIN_NAME = 'cloudflare_cached_domain_name';
 
     protected $wordPressWrapper;
+    public $logger;
 
     /**
      * @param DefaultLogger $logger

--- a/src/WordPress/Proxy.php
+++ b/src/WordPress/Proxy.php
@@ -17,6 +17,8 @@ class Proxy
     protected $wordpressIntegration;
     protected $requestRouter;
 
+    public $pluginAPI;
+
     /**
      * @param IntegrationInterface $integration
      */


### PR DESCRIPTION
Removes the following deprecation warning son PHP 8.2

```PHP
Deprecated: Creation of dynamic property CF\WordPress\DataStore::$logger is deprecated in /var/www/public_html/public/content/mu-plugins/cloudflare/src/WordPress/DataStore.php on line 23

Deprecated: Creation of dynamic property CF\WordPress\Proxy::$pluginAPI is deprecated in /var/www/public_html/public/content/mu-plugins/cloudflare/src/WordPress/Proxy.php on line 31
```