### PR TITLE
Fix Cloudflare Partners endpoint

### DIFF
--- a/src/API/Plugin.php
+++ b/src/API/Plugin.php
@@ -7,7 +7,7 @@ use CF\Integration\IntegrationInterface;
 class Plugin extends Client
 {
     const PLUGIN_API_NAME = 'PLUGIN API';
-    const ENDPOINT = 'https://partners.cloudflare/plugins/';
+    const ENDPOINT = 'https://partners.cloudflare.com/plugins/';
 
     //plugin/:id/settings/:human_readable_id setting names
     const SETTING_DEFAULT_SETTINGS = 'default_settings';


### PR DESCRIPTION
As reported by @kuliserper on Twitter
(https://twitter.com/kuliserper/status/1678028024527347712), the Cloudflare Partners endpoint was missing a `.com` at the end. This commit fixes that by adding it back.