### PR TITLE
Revert "Fix Cloudflare Partners endpoint"

### DIFF
--- a/src/API/Plugin.php
+++ b/src/API/Plugin.php
@@ -7,7 +7,7 @@ use CF\Integration\IntegrationInterface;
 class Plugin extends Client
 {
     const PLUGIN_API_NAME = 'PLUGIN API';
-    const ENDPOINT = 'https://partners.cloudflare.com/plugins/';
+    const ENDPOINT = 'https://partners.cloudflare/plugins/';
 
     //plugin/:id/settings/:human_readable_id setting names
     const SETTING_DEFAULT_SETTINGS = 'default_settings';


### PR DESCRIPTION
### 🔖 Summary

As reported [here](https://wordpress.org/support/topic/4-12-1-breaks-admin-interface/#post-16904159), it seems that my previous change https://github.com/cloudflare/Cloudflare-WordPress/pull/514 actually broke things.

This reverts commit fdeece676c1fe11166c9e5a4212616ec73b32ea7.