### PR TITLE
release 4.12.2

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -3,7 +3,7 @@
 Plugin Name: Cloudflare
 Plugin URI: https://blog.cloudflare.com/new-wordpress-plugin/
 Description: Cloudflare speeds up and protects your WordPress site.
-Version: 4.12.1
+Version: 4.12.2
 Requires PHP: 7.2
 Author: Cloudflare, Inc.
 License: BSD-3-Clause

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "_comment": [
     "php-compatibility-install comes from https://github.com/wimg/PHPCompatibility/issues/102#issuecomment-255778195"
   ],
-  "version": "4.12.1",
+  "version": "4.12.2",
   "config": {
     "platform": {
       "php": "7.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a1665ca197f72c55ea3ce6c42899416",
+    "content-hash": "a987cff52dafa5d452325c87a697c037",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",

--- a/config.json
+++ b/config.json
@@ -25,5 +25,5 @@
   },
   "locale": "en",
   "integrationName": "wordpress",
-  "version": "4.12.1"
+  "version": "4.12.2"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: icyapril, manatarms, thillcf, deuill, epatryk, jacobbednarz
 Tags: cloudflare, seo, ssl, ddos, speed, security, cdn, performance, free
 Requires at least: 3.4
 Tested up to: 6.2
-Stable tag: 4.12.1
+Stable tag: 4.12.2
 Requires PHP: 7.2
 License: BSD-3-Clause
 
@@ -98,6 +98,10 @@ Yes, Cloudflare works with, and helps speed up your site even more, if you have 
 == Screenshots ==
 
 == Changelog ==
+= 4.12.2 - 2023-07-18 =
+
+* Revert the incorrect fix to Cloudflare Partners endpoint
+
 = 4.12.1 - 2023-07-18 =
 
 * Fix Cloudflare Partners endpoint


### PR DESCRIPTION
This release deploys the following revert https://github.com/cloudflare/Cloudflare-WordPress/pull/516.