### PR TITLE
Prevent usage of `cloudflare_proxy` action on /admin-ajax endpoint for non-Administrator users

### DIFF
--- a/src/Integration/IntegrationAPIInterface.php
+++ b/src/Integration/IntegrationAPIInterface.php
@@ -53,4 +53,9 @@ interface IntegrationAPIInterface
      * @return mixed
      */
     public function getUserId();
+
+    /**
+     * @return boolean
+     */
+    public function isCurrentUserAdministrator();
 }

--- a/src/Test/WordPress/HooksTest.php
+++ b/src/Test/WordPress/HooksTest.php
@@ -76,6 +76,7 @@ class HooksTest extends \PHPUnit\Framework\TestCase
 
     public function testInitProxyCallsProxyRun()
     {
+        $this->mockWordPressAPI->method('isCurrentUserAdministrator')->willReturn(true);
         $this->mockProxy->expects($this->once())->method('run');
         $this->hooks->initProxy();
     }

--- a/src/Test/WordPress/ProxyTest.php
+++ b/src/Test/WordPress/ProxyTest.php
@@ -55,6 +55,7 @@ class ProxyTest extends \PHPUnit\Framework\TestCase
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_GET['proxyURL'] = 'proxyUrl';
         $_GET['proxyURLType'] = 'proxyUrlType';
+        $this->mockWordPressAPI->method('isCurrentUserAdministrator')->willReturn(true);
         $this->mockRequestRouter->expects($this->once())->method('route');
         $mockWPDie = $this->getFunctionMock('CF\WordPress', 'wp_die');
         $this->mockProxy->run();
@@ -72,6 +73,7 @@ class ProxyTest extends \PHPUnit\Framework\TestCase
         $mockFileGetContents->expects($this->any())->willReturn($jsonBody);
         $mockWPVerifyNonce = $this->getFunctionMock('CF\WordPress', 'wp_verify_nonce');
         $mockWPVerifyNonce->expects($this->once())->willReturn(true);
+        $this->mockWordPressAPI->method('isCurrentUserAdministrator')->willReturn(true);
         $this->mockRequestRouter->expects($this->once())->method('route');
         $mockWPDie = $this->getFunctionMock('CF\WordPress', 'wp_die');
         $this->mockProxy->run();

--- a/src/WordPress/Proxy.php
+++ b/src/WordPress/Proxy.php
@@ -53,6 +53,10 @@ class Proxy
 
     public function run()
     {
+        if (!$this->wordpressAPI->isCurrentUserAdministrator()) {
+            return;
+        }
+
         header('Content-Type: application/json');
 
         $request = $this->createRequest();

--- a/src/WordPress/WordPressAPI.php
+++ b/src/WordPress/WordPressAPI.php
@@ -155,4 +155,12 @@ class WordPressAPI implements IntegrationAPIInterface
 
         return false;
     }
+
+    /**
+     * @return boolean
+     */
+    public function isCurrentUserAdministrator()
+    {
+        return $this->wordPressWrapper->currentUserCan('administrator');
+    }
 }

--- a/src/WordPress/WordPressWrapper.php
+++ b/src/WordPress/WordPressWrapper.php
@@ -35,4 +35,9 @@ class WordPressWrapper
 
         return strtolower($site_url);
     }
+
+    public function currentUserCan($capabilities)
+    {
+        return current_user_can($capabilities);
+    }
 }


### PR DESCRIPTION
**🔖 Summary**

The implementation of this plugin is hidden behind a [`is_admin()` WordPress function](https://developer.wordpress.org/reference/functions/is_admin/).
However, as stated in the documentation:

> Does not check if the user is an administrator; use current_user_can()
> for checking roles and capabilities.

This commit is about ensuring that the `cloudflare_proxy` action on the
/admin-ajax endpoint is correctly limited to Administrator users only
before making any call via the Proxy to Cloudflare.

**✅ Testing plan**

Update the mocked tests which were rightfully failing due to non-Administrator
calls.
