### PR TITLE
CUSTESC-36595: Retrieve the Wordpress domain only from the active zone

### DIFF
--- a/src/WordPress/ClientActions.php
+++ b/src/WordPress/ClientActions.php
@@ -44,7 +44,15 @@ class ClientActions
         // We tried to fetch a zone but it's possible we're using an API token,
         // So try again with a zone name filtered API call
         if (!$this->api->responseOk($response)) {
-            $zoneRequest = new Request('GET', 'zones/', array('name' => idn_to_ascii($this->wordpressAPI->getOriginalDomain(), IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46), array()));
+            $zoneRequest = new Request(
+                'GET',
+                'zones/',
+                array(
+                    'name' => idn_to_ascii($this->wordpressAPI->getOriginalDomain(), IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46),
+                    'status' => 'active',
+                ),
+                null
+            );
             $zoneResponse = $this->api->callAPI($zoneRequest);
 
             return $zoneResponse;

--- a/src/WordPress/WordPressClientAPI.php
+++ b/src/WordPress/WordPressClientAPI.php
@@ -22,7 +22,7 @@ class WordPressClientAPI extends Client
             return $zone_tag;
         }
 
-        $request = new Request('GET', 'zones/', array('name' => $zone_name), array());
+        $request = new Request('GET', 'zones/', array('name' => $zone_name, 'status' => 'active'), null);
         $response = $this->callAPI($request);
 
         $zone_tag = null;


### PR DESCRIPTION
We recently noticed that a user got its zone incorrectly reported as inactive by the Wordpress plugin. After some investigations, it seems that two zones actually existed: an old purged one, and a new active zone. To guarantee that the plugin always retrieve the active one, if any, this commit changes the zone retrieval call to the Cloudflare API by adding a `status=active` query parameter to the request, [as documented here](https://developers.cloudflare.com/api/operations/zones-get).