### PR TITLE
Allow `psr/log` v3 when using composer

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -1,6 +1,8 @@
 <?php
 
-require_once __DIR__.'/vendor/autoload.php';
+if (!class_exists('CloudFlare\IpRewrite')) {
+	require_once __DIR__.'/vendor/autoload.php';
+}
 
 use CloudFlare\IpRewrite;
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "cloudflare/cf-ip-rewrite": "^1.0.0",
     "symfony/polyfill-intl-idn": "*",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0 || ^3.0"
   },
   "require-dev": {
     "symfony/yaml": "~2.6",
@@ -40,5 +40,8 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "extra": {
+    "installer-name": "cloudflare"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8665bcdae6db5846ed6b42aef3e563e",
+    "content-hash": "38f0352fff5fc31da5152c8912eb191e",
     "packages": [
         {
             "name": "cloudflare/cf-ip-rewrite",

--- a/src/Integration/DefaultLogger.php
+++ b/src/Integration/DefaultLogger.php
@@ -6,6 +6,9 @@ use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 
+# if (Psr\Log version < 2)
+if (class_exists('Psr\Log\Test\DummyTest')):
+
 class DefaultLogger extends AbstractLogger implements LoggerInterface
 {
     private $debug;
@@ -46,3 +49,48 @@ class DefaultLogger extends AbstractLogger implements LoggerInterface
         }
     }
 }
+
+else:
+
+class DefaultLogger extends AbstractLogger implements LoggerInterface
+{
+    private $debug;
+
+    const PREFIX = '[Cloudflare]';
+
+    /**
+     * @param bool|false $debug
+     */
+    public function __construct($debug = false)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param Stringable|string $message
+     * @param array  $context
+     */
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        error_log(self::PREFIX.' '.strtoupper($level).': '.$message.' '.
+            (!empty($context) ? print_r($context, true) : ''));
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param Stringable|string $message
+     * @param array  $context
+     */
+    public function debug(Stringable|string $message, array $context = []): void
+    {
+        if ($this->debug) {
+            $this->log(LogLevel::DEBUG, $message, $context);
+        }
+    }
+}
+
+endif;


### PR DESCRIPTION
Alternative solution for #539.
This helps to work around the issue regarding the conflicted dependencies (specifically `Psr\Log` package).
This would allow installing the package on a PHP 8 server via Composer, while keeping the wp.org plugin a PHP 7.x target.

> [!NOTE]
> This change requires the plugin to be published as a standard package on Packagist and then be released with a new tag.
> https://packagist.org/packages/submit

> [!Warning]
> A conditional class definition is unfortunately required to match `psr/log` methods signatures.
> This is not very pretty, but, again, required.
> [`b6e81b9`](https://github.com/cloudflare/Cloudflare-WordPress/pull/541/commits/b6e81b9ba1bd64d3a12ea31c363d119cb3d44bb4)

---
* Closes #539
* Resolves #490
* Resolves #470
* Resolves #445 
* Ref #528
* Closes Cloudflare case 3130507
* Ref https://wordpress.org/support/topic/compatibility-with-php-8-2-20/
* Ref https://wordpress.org/support/topic/php-function-deprecated-php-in-8-2/
* Ref https://wordpress.org/support/topic/w3totalcache-cloudflare-extension-vs-cloudflare-apo-wordpress-plugin/
* Ref https://wordpress.org/support/topic/fatal-error-on-plugin-activation-42/
* Ref https://wordpress.org/support/topic/php-fatal-error-psrlog-php8/

---

cc @Korben00