### PR TITLE
Fix empty settings page for users with `manage_options` capability without administrator role

### DIFF
--- a/src/WordPress/WordPressAPI.php
+++ b/src/WordPress/WordPressAPI.php
@@ -161,6 +161,6 @@ class WordPressAPI implements IntegrationAPIInterface
      */
     public function isCurrentUserAdministrator()
     {
-        return $this->wordPressWrapper->currentUserCan('administrator');
+        return $this->wordPressWrapper->currentUserCan('manage_options');
     }
 }


### PR DESCRIPTION
The WordPress admin settings page of the Cloudflare plugin is empty for users having the `manage_options` capability without the administrator role (as is the case with for example a custom 'Manager' role).

This PR intends to fix #544 which describes this issue, by using the same `manage_options` capability check for the admin menu page and the 'Cloudflare proxy':

> The "Cloudflare" admin menu item requires the `manage_options` capability and the WordPress AJAX action `cloudflare_proxy` — which seems needed to load the settings page — is checking for the `administrator` role.

Can you take a look at this, @aseure?