### PR TITLE
Add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: New release


### PR DESCRIPTION
Adds permissions: contents: write to the release workflow to follow the principle of least privilege. This prevents the workflow from inheriting potentially overly permissive default repository/organization permissions and explicitly declares only the write access needed for uploading release assets.