### PR TITLE
feat: add cache-tag header support

### DIFF
--- a/cloudflare.loader.php
+++ b/cloudflare.loader.php
@@ -43,6 +43,9 @@ if (defined('CLOUDFLARE_HTTP2_SERVER_PUSH_ACTIVE') && CLOUDFLARE_HTTP2_SERVER_PU
     add_action('init', array($cloudflareHooks, 'http2ServerPushInit'));
 }
 
+// Enable Cache Tags
+add_action('init', array($cloudflareHooks, 'cacheTagsInit'));
+
 add_action('init', array($cloudflareHooks, 'initAutomaticPlatformOptimization'));
 
 if (is_admin()) {

--- a/cloudflare.php
+++ b/cloudflare.php
@@ -26,6 +26,9 @@ License: BSD-3-Clause
 // To enable error logging when HTTP/2 Server Push header size is exceeded:
 // define('CLOUDFLARE_HTTP2_SERVER_PUSH_LOG', true);
 
+// To enable debug headers for Cache Tags:
+// define('CLOUDFLARE_CACHE_TAGS_DEBUG', true);
+
 // Exit if accessed directly
 if (!defined('ABSPATH')) {
     exit;

--- a/src/Test/WordPress/CacheTagsHeaderTest.php
+++ b/src/Test/WordPress/CacheTagsHeaderTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Cloudflare\APO\Test\WordPress;
+
+use Cloudflare\APO\WordPress\CacheTagsHeader;
+use phpmock\phpunit\PHPMock;
+
+class CacheTagsHeaderTest extends \PHPUnit\Framework\TestCase
+{
+    use PHPMock;
+
+    public function testInitRegistersHook()
+    {
+        $mockAddAction = $this->getFunctionMock('Cloudflare\APO\WordPress', 'add_action');
+        $mockAddAction->expects($this->once())
+            ->with('send_headers', [CacheTagsHeader::class, 'send_cache_tag_headers'], 20);
+
+        CacheTagsHeader::init();
+    }
+
+    public function testSendCacheTagHeadersDoesNothingIfShouldNotTag()
+    {
+        $mockApplyFilters = $this->getFunctionMock('Cloudflare\APO\WordPress', 'apply_filters');
+        $mockApplyFilters->expects($this->any())->willReturnCallback(function($hook, $value) {
+            if ($hook === 'cf_cache_tags_enabled') {
+                return false;
+            }
+            return $value;
+        });
+
+        $mockHeader = $this->getFunctionMock('Cloudflare\APO\WordPress', 'header');
+        $mockHeader->expects($this->never());
+
+        CacheTagsHeader::send_cache_tag_headers();
+    }
+
+    public function testSendCacheTagHeadersSendsHomeTagOnFrontPage()
+    {
+        // Mock should_tag_response to return true
+        $mocks = $this->setupShouldTagMocks(true);
+        $mockApplyFilters = $mocks['apply_filters'];
+
+        // Mock build_tags dependencies
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_front_page')->expects($this->any())->willReturn(true);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_home')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_category')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_tag')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_tax')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_singular')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_post_type_archive')->expects($this->any())->willReturn(false);
+
+        $mockHeader = $this->getFunctionMock('Cloudflare\APO\WordPress', 'header');
+        $mockHeader->expects($this->once())
+            ->with('Cache-Tag:home', false);
+
+        CacheTagsHeader::send_cache_tag_headers();
+    }
+
+    public function testSanitizeTag()
+    {
+        $reflection = new \ReflectionClass(CacheTagsHeader::class);
+        $method = $reflection->getMethod('sanitize_tag');
+        $method->setAccessible(true);
+
+        $this->assertEquals('tag', $method->invoke(null, 'TAG'));
+        $this->assertEquals('tag', $method->invoke(null, 'tag '));
+        $this->assertEquals('tagname', $method->invoke(null, 'tag name'));
+        $this->assertEquals('tag_name', $method->invoke(null, 'tag,name'));
+        $this->assertEquals('tag_name', $method->invoke(null, 'tag___name'));
+        $this->assertEquals('!!!tag!!!', $method->invoke(null, '!!!tag!!!'));
+        $this->assertEquals('tag', $method->invoke(null, ''));
+    }
+
+    public function testSanitizeTagTruncatesLongTags()
+    {
+        $reflection = new \ReflectionClass(CacheTagsHeader::class);
+        $method = $reflection->getMethod('sanitize_tag');
+        $method->setAccessible(true);
+
+        $longTag = str_repeat('a', 2000);
+        $sanitized = $method->invoke(null, $longTag);
+
+        $this->assertEquals(1024, strlen($sanitized));
+        $this->assertEquals(str_repeat('a', 1024), $sanitized);
+    }
+
+    public function testSendCacheTagHeadersChunksLargeTags()
+    {
+        // Combine all filter logic into one callback to avoid phpmock conflicts
+        $largeTags = [];
+        for ($i = 0; $i < 100; $i++) {
+            $largeTags[] = str_repeat('a', 100) . $i;
+        }
+
+        $mockApplyFilters = $this->getFunctionMock('Cloudflare\APO\WordPress', 'apply_filters');
+        $mockApplyFilters->expects($this->any())->willReturnCallback(function($hook, $value) use ($largeTags) {
+            if ($hook === 'cf_cache_tags_enabled') {
+                return true;
+            }
+            if ($hook === 'cf_cache_tags') {
+                return $largeTags;
+            }
+            return $value;
+        });
+
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_admin')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'wp_doing_ajax')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_feed')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_trackback')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_robots')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_favicon')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'headers_sent')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_front_page')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_home')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_category')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_tag')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_tax')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_singular')->expects($this->any())->willReturn(false);
+        $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_post_type_archive')->expects($this->any())->willReturn(false);
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $mockHeader = $this->getFunctionMock('Cloudflare\APO\WordPress', 'header');
+        $mockHeader->expects($this->exactly(2));
+
+        CacheTagsHeader::send_cache_tag_headers();
+    }
+
+    private function setupShouldTagMocks($enabled = true)
+    {
+        $mockApplyFilters = $this->getFunctionMock('Cloudflare\APO\WordPress', 'apply_filters');
+        $mockApplyFilters->expects($this->any())->willReturnCallback(function($hook, $value) use ($enabled) {
+            if ($hook === 'cf_cache_tags_enabled') {
+                return $enabled;
+            }
+            return $value;
+        });
+
+        $mockIsAdmin = $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_admin');
+        $mockIsAdmin->expects($this->any())->willReturn(false);
+
+        $mockWpDoingAjax = $this->getFunctionMock('Cloudflare\APO\WordPress', 'wp_doing_ajax');
+        $mockWpDoingAjax->expects($this->any())->willReturn(false);
+
+        $mockIsFeed = $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_feed');
+        $mockIsFeed->expects($this->any())->willReturn(false);
+
+        $mockIsTrackback = $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_trackback');
+        $mockIsTrackback->expects($this->any())->willReturn(false);
+
+        $mockIsRobots = $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_robots');
+        $mockIsRobots->expects($this->any())->willReturn(false);
+
+        $mockIsFavicon = $this->getFunctionMock('Cloudflare\APO\WordPress', 'is_favicon');
+        $mockIsFavicon->expects($this->any())->willReturn(false);
+
+        $mockHeadersSent = $this->getFunctionMock('Cloudflare\APO\WordPress', 'headers_sent');
+        $mockHeadersSent->expects($this->any())->willReturn(false);
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        return [
+            'apply_filters' => $mockApplyFilters,
+            'is_admin' => $mockIsAdmin,
+        ];
+    }
+}

--- a/src/WordPress/CacheTagsHeader.php
+++ b/src/WordPress/CacheTagsHeader.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Cloudflare\APO\WordPress;
+
+final class CacheTagsHeader
+{
+    const HEADER_NAME = 'Cache-Tag';
+
+    public static function init(): void
+    {
+        add_action('send_headers', [__CLASS__, 'send_cache_tag_headers'], 20);
+    }
+
+    /**
+     * Decide whether to tag this response at all.
+     */
+    private static function should_tag_response(): bool
+    {
+        // Allow turning off via filter.
+        $enabled = apply_filters('cf_cache_tags_enabled', true);
+        if (!$enabled) {
+            return false;
+        }
+
+        // Avoid non-front-end contexts.
+        if (is_admin()) {
+            return false;
+        }
+        if (function_exists('wp_doing_ajax') && wp_doing_ajax()) {
+            return false;
+        }
+        if (defined('REST_REQUEST') && REST_REQUEST) {
+            return false;
+        }
+
+        // Avoid responses that generally shouldn't be edge-cached.
+        if (is_feed() || is_trackback() || is_robots() || (function_exists('is_favicon') && is_favicon())) {
+            return false;
+        }
+
+        // Only for safe cacheable methods.
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        if (!in_array($method, ['GET', 'HEAD'], true)) {
+            return false;
+        }
+
+        // If headers already sent, we can't add ours.
+        if (headers_sent()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Sanitize a tag to printable ASCII without spaces (Cloudflare requirement).
+     */
+    private static function sanitize_tag(string $tag): string
+    {
+        $tag = strtolower($tag);
+        $tag = str_replace(' ', '', $tag);            // Spaces not allowed
+        // Keep only printable ASCII; replace other chars with underscore
+        $tag = preg_replace('/[^\x21-\x7E]/', '_', $tag);
+        // Remove commas (since commas are separators in the header)
+        $tag = str_replace(',', '_', $tag);
+        // Collapse repeats
+        $tag = preg_replace('/_+/', '_', $tag);
+        // Trim separators
+        $tag = trim($tag, "_-:");
+        // Truncate to 1024 chars (Cloudflare API limit for purging)
+        $tag = substr($tag, 0, 1024);
+        // Ensure at least 1 byte
+        return $tag !== '' ? $tag : 'tag';
+    }
+
+    /**
+     * Build the tag list based on WP conditionals.
+     */
+    private static function build_tags(): array
+    {
+        $tags = [];
+
+        // Home (front page or posts page)
+        if (is_front_page() || is_home()) {
+            $tags[] = 'home';
+        }
+
+        // Taxonomy archives: category, tag, custom tax
+        if (is_category() || is_tag() || is_tax()) {
+            $term = get_queried_object();
+            if ($term && !empty($term->taxonomy)) {
+                $taxonomy = (string) $term->taxonomy;
+                $tags[] = 'tax:' . $taxonomy; // {taxonomy_name}
+            }
+        }
+
+        // Post type single: post, page, custom post types
+        if (is_singular()) {
+            $pt = get_post_type();
+            if ($pt) {
+                $tags[] = 'pt:' . $pt;
+            }
+        }
+
+        // Post type archive
+        if (is_post_type_archive()) {
+            $pt = get_query_var('post_type');
+            if (is_array($pt)) {
+                foreach ($pt as $one) {
+                    if ($one) {
+                        $tags[] = 'pt:' . $one;
+                        $tags[] = 'pt_archive:' . $one;
+                    }
+                }
+            } elseif (is_string($pt) && $pt !== '') {
+                $tags[] = 'pt:' . $pt;
+                $tags[] = 'pt_archive:' . $pt;
+            } else {
+                // Fallback: sometimes queried object can help
+                $obj = get_queried_object();
+                if ($obj && !empty($obj->name)) {
+                    $tags[] = 'pt:' . (string) $obj->name;
+                    $tags[] = 'pt_archive:' . (string) $obj->name;
+                }
+            }
+        }
+
+        // Let you extend/override tags.
+        $tags = apply_filters('cf_cache_tags', $tags);
+
+        // Sanitize + unique
+        $tags = array_values(array_unique(array_map([__CLASS__, 'sanitize_tag'], $tags)));
+
+        return $tags;
+    }
+
+    /**
+     * Send Cache-Tag headers. Cloudflare supports multiple Cache-Tag header fields.
+     * Also keep the aggregate header size under 16KB.
+     */
+    public static function send_cache_tag_headers(): void
+    {
+        if (!self::should_tag_response()) {
+            return;
+        }
+
+        $tags = self::build_tags();
+        if (!$tags) {
+            return;
+        }
+
+        // Chunk tags into multiple headers to stay safely under limits.
+        // Cloudflare aggregate Cache-Tag header size limit is 16KB.
+        $maxBytesPerHeader = 7500; // conservative; allows multiple headers well under 16KB aggregate
+        $current = [];
+        $currentLen = 0;
+
+        foreach ($tags as $tag) {
+            $tagLen = strlen($tag);
+            $extra = ($currentLen === 0) ? $tagLen : ($tagLen + 1); // + comma
+            if ($currentLen + $extra > $maxBytesPerHeader) {
+                header(self::HEADER_NAME . ':' . implode(',', $current), false);
+                $current = [$tag];
+                $currentLen = $tagLen;
+            } else {
+                $current[] = $tag;
+                $currentLen += $extra;
+            }
+        }
+
+        if (!empty($current)) {
+            header(self::HEADER_NAME . ':' . implode(',', $current), false);
+        }
+
+        /**
+         * Optional debugging: Cloudflare removes Cache-Tag before sending to visitors.
+         * If you want to see what was generated at origin, enable this:
+         *
+         * define('CLOUDFLARE_CACHE_TAGS_DEBUG', true);
+         */
+        if (defined('CLOUDFLARE_CACHE_TAGS_DEBUG') && CLOUDFLARE_CACHE_TAGS_DEBUG) {
+            header('X-Test-Cache-Tag:' . implode(',', $tags), true);
+        }
+    }
+}

--- a/src/WordPress/Hooks.php
+++ b/src/WordPress/Hooks.php
@@ -413,6 +413,11 @@ class Hooks
         HTTP2ServerPush::init();
     }
 
+    public function cacheTagsInit()
+    {
+        CacheTagsHeader::init();
+    }
+
     /*
      * php://input can only be read once before PHP 5.6, try to grab it ONLY if the request
      * is coming from the cloudflare proxy.  We store it in a global so \Cloudflare\APO\WordPress\Proxy


### PR DESCRIPTION
I found myself needing ability to purge WordPress (html) pages by tags, e.g. ability to purge all posts, pages, or some other custom post type after deploying changes that affect only a certain part/template of the website. Purge everything is okay, but many times we don't want to purge static assets or other sections of the website.

I thought the feature could be useful to others as well.

Please review and let me know in case any changes are needed. @aseure
Please comment on `$maxBytesPerHeader`, it's there to prevent errors on default 8k limit of `fastcgi_buffer_size`. Also, does Cloudflare read multiple Cache-Tag headers correctly?

Basic tests added:
`./vendor/bin/phpunit ./src/Test/WordPress/CacheTagsHeaderTest.php --testdox`

Reference: https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/


# Cloudflare Cache-Tags for WordPress

This feature automatically adds `Cache-Tag` HTTP response headers to your WordPress front-end pages. These tags allow for granular cache purging via the Cloudflare API or Dashboard.

The implementation is located in `src/WordPress/CacheTagsHeader.php`.

## Automatically Generated Tags

The following tags are generated based on the WordPress page context:

| Page Type | Generated Tag(s) | Example |
| :--- | :--- | :--- |
| **Home / Front Page** | `home` | `Cache-Tag: home` |
| **Single Post/Page** | `pt:{post_type}` | `Cache-Tag: pt:post`, `Cache-Tag: pt:page` |
| **Taxonomy Archive** | `tax:{taxonomy}` | `Cache-Tag: tax:category`, `Cache-Tag: tax:post_tag` |
| **Post Type Archive** | `pt:{post_type}`, `pt_archive:{post_type}` | `Cache-Tag: pt:product,pt_archive:product` |

## Sanitization & Limits

To ensure compatibility with Cloudflare's edge requirements, all tags undergo the following sanitization:

*   **Lowercase**: All tags are converted to lowercase.
*   **No Spaces**: Spaces are removed entirely.
*   **ASCII Only**: Non-printable ASCII characters are replaced with underscores.
*   **No Commas**: Commas (used as separators) are replaced with underscores within tags.
*   **Length Limit**: Individual tags are truncated to **1024 characters** (Cloudflare API limit).
*   **Header Chunking**: If the total size of tags exceeds **7.5 KB**, the plugin automatically splits them into multiple `Cache-Tag` header fields to stay safely within Cloudflare's 16 KB aggregate limit.

## Developer Hooks

### Disable Cache-Tags
Use this filter to turn off the functionality entirely:
```php
add_filter('cf_cache_tags_enabled', '__return_false');
```

Add Custom Tags
Extend the list of tags sent to Cloudflare:
```php
<?php
add_filter('cf_cache_tags', function($tags) {
    $tags[] = 'my-custom-tag';
    return $tags;
});
```

## Debugging
You can inspect the generated tags without them being stripped by Cloudflare by enabling debug mode in your `wp-config.php`. This will output an `X-Test-Cache-Tag` header containing all generated tags:
```php
<?php
define('CLOUDFLARE_CACHE_TAGS_DEBUG', true);
```
