### PR TITLE
Update .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -41,7 +41,7 @@
 </FilesMatch>
 
 # Cloudflare fonts
-<FilesMatch "^.+(eot|ttf||otf|woff|woff2)$">
+<FilesMatch "^.+(eot|ttf|otf|woff|woff2)$">
         # Apache 2.2
         <IfModule !mod_authz_core.c>
                 Allow from all


### PR DESCRIPTION
<FilesMatch "^.+(eot|ttf||otf|woff|woff2)$">

The double pipes after ttf allow any file type (it breaks the regex and is a security risk).