### PR TITLE
Fix Apply settings fail-fast when using Account Owned Tokens

### DIFF
--- a/src/API/Exception/ZoneSettingFailException.php
+++ b/src/API/Exception/ZoneSettingFailException.php
@@ -5,4 +5,12 @@ namespace Cloudflare\APO\API\Exception;
 class ZoneSettingFailException extends CloudFlareException
 {
     protected $message = 'Oops, something went wrong, please try again in a few minutes';
+
+    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    {
+        if ($message !== null) {
+            $this->message = $message;
+        }
+        parent::__construct($this->message, $code, $previous);
+    }
 }

--- a/src/Test/WordPress/PluginActionsTest.php
+++ b/src/Test/WordPress/PluginActionsTest.php
@@ -105,19 +105,79 @@ class PluginActionsTest extends \PHPUnit\Framework\TestCase
         $this->pluginActions->applyDefaultSettings();
     }
 
-    public function testReturnApplyDefaultSettingsChangeZoneSettingsThrowsZoneSettingFailException()
+    public function testReturnApplyDefaultSettingsChangeZoneSettingsThrowsWithFailedSettingNames()
     {
         $this->expectException('\Cloudflare\APO\API\Exception\ZoneSettingFailException');
+        $this->expectExceptionMessageMatches('/Failed to update the following settings/');
 
         $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
 
-        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(false);
-
-        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(true);
+        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
+            array(
+                'result' => array(
+                    'plan' => array(
+                        'legacy_id' => Plans::FREE_PLAN,
+                    ),
+                ),
+            )
+        );
         $this->mockWordPressClientAPI->method('responseOk')->willReturn(true);
+        // All settings fail
         $this->mockWordPressClientAPI->method('changeZoneSettings')->willReturn(false);
-
+        // All 13 settings (Free plan) should still be attempted despite failures
+        $this->mockWordPressClientAPI->expects($this->exactly(13))->method('changeZoneSettings');
 
         $this->pluginActions->applyDefaultSettings();
+    }
+
+    public function testApplyDefaultSettingsContinuesAfterPartialFailure()
+    {
+        $this->expectException('\Cloudflare\APO\API\Exception\ZoneSettingFailException');
+        $this->expectExceptionMessageMatches('/hotlink_protection/');
+        $this->expectExceptionMessageMatches('/remaining settings were applied successfully/');
+
+        $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
+
+        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
+            array(
+                'result' => array(
+                    'plan' => array(
+                        'legacy_id' => Plans::FREE_PLAN,
+                    ),
+                ),
+            )
+        );
+        $this->mockWordPressClientAPI->method('responseOk')->willReturn(true);
+        // Only hotlink_protection (11th call, index 10) fails
+        $this->mockWordPressClientAPI->method('changeZoneSettings')->willReturnOnConsecutiveCalls(
+            true, true, true, true, true, true, true, true, true, true,
+            false, // hotlink_protection
+            true, true
+        );
+        // All 13 settings should be attempted
+        $this->mockWordPressClientAPI->expects($this->exactly(13))->method('changeZoneSettings');
+
+        $this->pluginActions->applyDefaultSettings();
+    }
+
+    public function testApplyDefaultSettingsSucceedsWhenAllSettingsPass()
+    {
+        $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
+
+        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
+            array(
+                'result' => array(
+                    'plan' => array(
+                        'legacy_id' => Plans::FREE_PLAN,
+                    ),
+                ),
+            )
+        );
+        $this->mockWordPressClientAPI->method('responseOk')->willReturn(true);
+        $this->mockWordPressClientAPI->method('changeZoneSettings')->willReturn(true);
+
+        // Should not throw any exception
+        $this->pluginActions->applyDefaultSettings();
+        $this->assertTrue(true); // Explicit assertion that we reached this point
     }
 }

--- a/src/WordPress/PluginActions.php
+++ b/src/WordPress/PluginActions.php
@@ -78,93 +78,55 @@ class PluginActions extends AbstractPluginActions
         $path_array = explode('/', $this->request->getUrl());
         $zoneId = $path_array[1];
 
-        $result = true;
         $details = $this->clientAPI->zoneGetDetails($zoneId);
 
         if (!$this->clientAPI->responseOk($details)) {
-            // Technically zoneGetDetails does not try to set Zone Settings
-            // Can create a new exception but make things simple right?
             throw new ZoneSettingFailException();
         }
 
         $currentPlan = $details['result']['plan']['legacy_id'] ?? 'free';
 
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'security_level', array('value' => 'medium'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'cache_level', array('value' => 'aggressive'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'browser_cache_ttl', array('value' => 14400));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'always_online', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'development_mode', array('value' => 'off'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'ipv6', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'websockets', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'ip_geolocation', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'email_obfuscation', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'server_side_exclude', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'hotlink_protection', array('value' => 'off'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'rocket_loader', array('value' => 'off'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
-
-        $result &= $this->clientAPI->changeZoneSettings($zoneId, 'automatic_https_rewrites', array('value' => 'on'));
-        if (!$result) {
-            throw new ZoneSettingFailException();
-        }
+        // Define the recommended settings to apply
+        $settings = array(
+            array('name' => 'security_level', 'params' => array('value' => 'medium')),
+            array('name' => 'cache_level', 'params' => array('value' => 'aggressive')),
+            array('name' => 'browser_cache_ttl', 'params' => array('value' => 14400)),
+            array('name' => 'always_online', 'params' => array('value' => 'on')),
+            array('name' => 'development_mode', 'params' => array('value' => 'off')),
+            array('name' => 'ipv6', 'params' => array('value' => 'on')),
+            array('name' => 'websockets', 'params' => array('value' => 'on')),
+            array('name' => 'ip_geolocation', 'params' => array('value' => 'on')),
+            array('name' => 'email_obfuscation', 'params' => array('value' => 'on')),
+            array('name' => 'server_side_exclude', 'params' => array('value' => 'on')),
+            array('name' => 'hotlink_protection', 'params' => array('value' => 'off')),
+            array('name' => 'rocket_loader', 'params' => array('value' => 'off')),
+            array('name' => 'automatic_https_rewrites', 'params' => array('value' => 'on')),
+        );
 
         // If the plan supports Mirage and Polish try to set them on
         if (!Plans::planNeedsUpgrade($currentPlan, Plans::BIZ_PLAN)) {
-            $result &= $this->clientAPI->changeZoneSettings($zoneId, 'mirage', array('value' => 'on'));
-            if (!$result) {
-                throw new ZoneSettingFailException();
-            }
+            $settings[] = array('name' => 'mirage', 'params' => array('value' => 'on'));
+            $settings[] = array('name' => 'polish', 'params' => array('value' => 'lossless'));
+        }
 
-            $result &= $this->clientAPI->changeZoneSettings($zoneId, 'polish', array('value' => 'lossless'));
+        // Apply all settings, collecting failures rather than failing fast.
+        // Some API endpoints may return errors for certain token types (e.g.
+        // Account Owned Tokens) even when the token has the correct permissions.
+        // Skipping individual failures ensures remaining settings still apply.
+        $failedSettings = array();
+        foreach ($settings as $setting) {
+            $result = $this->clientAPI->changeZoneSettings($zoneId, $setting['name'], $setting['params']);
             if (!$result) {
-                throw new ZoneSettingFailException();
+                $failedSettings[] = $setting['name'];
             }
+        }
+
+        if (!empty($failedSettings)) {
+            $message = 'Failed to update the following settings: ' . implode(', ', $failedSettings)
+                . '. The remaining settings were applied successfully.'
+                . ' If you are using an Account Owned Token, some zone settings'
+                . ' endpoints may not yet support this token type.';
+            throw new ZoneSettingFailException($message);
         }
     }
 


### PR DESCRIPTION
## Summary

The "Apply Recommended Cloudflare Settings for WordPress" button fails with a generic "Oops, something went wrong" error when the plugin is authenticated using an Account Owned Token (AOT). Investigation revealed two separate issues:

1. **API bug:** `PATCH /zones/{zone}/settings/hotlink_protection` returns HTTP 500 ("unhandled server error") when called with an Account Owned Token, despite the endpoint being zone-scoped and theoretically AOT-compatible per the AOT design principles. The same request succeeds with a User API Token. This is believed to be caused by the Scrape Shield service not yet being updated to support the AOT JWT type.

2. **Plugin bug (this PR):** The `applyDefaultSettings()` method applies settings sequentially with a fail-fast pattern - if any single setting returns an error, the entire operation is aborted and all subsequent settings are skipped. This means when `hotlink_protection` fails (the 11th of 13 settings), the user gets a generic error and the remaining two settings (`rocket_loader` and `automatic_https_rewrites`) are never applied, despite the first 10 settings having succeeded.

RE: `ESCALATION-1438`

## Changes

**`src/WordPress/PluginActions.php`**
- Replaced 13 individual fail-fast `if (!$result) throw` blocks with a data-driven loop that applies all settings independently
- Failures are collected rather than immediately thrown
- After all settings have been attempted, if any failed, a single exception is thrown with a specific message listing which settings failed and noting the possible AOT cause
- All settings that can be applied are now applied regardless of individual failures

**`src/API/Exception/ZoneSettingFailException.php`**
- Added constructor accepting an optional custom message
- Defaults to the existing generic message for backward compatibility
- Allows `applyDefaultSettings()` to surface specific failure details to the user

**`src/Test/WordPress/PluginActionsTest.php`**
- Updated existing fail-fast test to reflect new behaviour
- Added test for partial failure (some settings fail, others succeed)
- Added test for complete failure (all settings fail)
- Added test for full success path

## Reproduction

1. Create an Account Owned Token (AOT) using the WordPress template at `/:account/api-tokens`
2. Authenticate the Cloudflare WordPress plugin with the AOT
4. Click "Apply Recommended Cloudflare Settings for WordPress"
5. **Before this fix:** generic "Oops, something went wrong" error, no settings applied after `hotlink_protection`
6. **After this fix:** all other settings applied successfully, specific error message identifying `hotlink_protection` as the failing setting

## Testing

Tested on WordPress 6.9.4 with plugin v4.14.2 on a Business plan zone. Confirmed `hotlink_protection` 500 error with AOT via:

```bash
curl -s -X PATCH 'https://api.cloudflare.com/client/v4/zones/{zone}/settings/hotlink_protection' \
  -H 'Authorization: Bearer cfat_...' \
  -H 'Content-Type: application/json' \
  -d '{"value":"off"}'
# Returns: {"success":false,"errors":[{"code":500,"message":"unhandled server error"}]}
```

Same request with User API Token returns `success: true`.

## Note

The underlying API bug (500 on `hotlink_protection` with AOT) needs to be fixed separately. Once that is fixed, this plugin change still improves resilience against any future individual setting failures and provides better error messaging overall.