### PR TITLE
fix: recognize new cfk_/cfut_/cfat_ credential formats

### DIFF
--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -16,6 +16,47 @@ class Client extends AbstractAPIClient
     const USER_AGENT = 'User-Agent';
 
     /**
+     * Returns true when the supplied credential is a Cloudflare Global API
+     * Key (which uses the X-Auth-Email + X-Auth-Key header pair) and false
+     * for everything else (treated as an API Token sent via Authorization:
+     * Bearer).
+     *
+     * Cloudflare credential formats (see
+     * https://developers.cloudflare.com/fundamentals/api/get-started/token-formats/):
+     *   - Global API Key  (new):      "cfk_"  + 40 chars + checksum
+     *   - User API Token  (new):      "cfut_" + 40 chars + checksum
+     *   - Account API Token (new):    "cfat_" + 40 chars + checksum
+     *   - Global API Key  (pre-2026): 37-45 character lowercase hex string
+     *   - API Token       (pre-2026): 40-character alphanumeric string
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public static function isGlobalApiKey($key)
+    {
+        if (!is_string($key) || $key === '') {
+            return false;
+        }
+
+        // New scannable format: explicitly prefixed.
+        if (strncmp($key, 'cfk_', 4) === 0) {
+            return true;
+        }
+        if (strncmp($key, 'cfut_', 5) === 0 || strncmp($key, 'cfat_', 5) === 0) {
+            return false;
+        }
+
+        // Pre-2026 Global API Key: 37-45 lowercase hex characters.
+        $len = strlen($key);
+        if ($len >= 37 && $len <= 45 && preg_match('/^[0-9a-f]+$/', $key)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * @param Request $request
      *
      * @return Request
@@ -32,10 +73,10 @@ class Client extends AbstractAPIClient
         $wp_version = $GLOBALS['wp_version'] ?? 'unknown';
         $headers[self::USER_AGENT] =  'wordpress/' . $wp_version . '; cloudflare-wordpress-plugin/' . $version;
 
-        // Determine authentication method from key format. Global API keys are
-        // always returned in hexadecimal format, while API Tokens are encoded
-        // using a wider range of characters.
-        if (strlen($key) === self::AUTH_KEY_LEN && preg_match('/^[0-9a-f]+$/', $key)) {
+        // Cloudflare distinguishes Global API Keys (sent via X-Auth-Email +
+        // X-Auth-Key) from API Tokens (sent via Authorization: Bearer) by the
+        // credential format. See self::isGlobalApiKey().
+        if (self::isGlobalApiKey($key)) {
             $headers[self::X_AUTH_EMAIL] = $this->data_store->getCloudFlareEmail();
             $headers[self::X_AUTH_KEY] = $key;
         } else {

--- a/src/Test/API/ClientTest.php
+++ b/src/Test/API/ClientTest.php
@@ -56,6 +56,114 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedRequestHeaders[Client::CONTENT_TYPE_KEY], $actualRequestHeaders[Client::CONTENT_TYPE_KEY]);
     }
 
+    public function testBeforeSendUsesGlobalKeyHeadersForCfkPrefix()
+    {
+        // New-format Global API Key: "cfk_" + 40 chars + checksum.
+        // nosemgrep: generic.secrets.security.detected-generic-api-key.detected-generic-api-key
+        $apiKey = 'cfk_' . str_repeat('a', 40) . 'X1y2';
+        $email = 'test@email.com';
+
+        $this->mockDataStore->method('getClientV4APIKey')->willReturn($apiKey);
+        $this->mockDataStore->method('getCloudFlareEmail')->willReturn($email);
+
+        $request = new \Cloudflare\APO\API\Request(null, null, null, null);
+        $beforeSendRequest = $this->mockClientAPI->beforeSend($request);
+
+        $headers = $beforeSendRequest->getHeaders();
+
+        $this->assertSame($apiKey, $headers[Client::X_AUTH_KEY]);
+        $this->assertSame($email, $headers[Client::X_AUTH_EMAIL]);
+        $this->assertArrayNotHasKey(Client::AUTHORIZATION, $headers);
+    }
+
+    public function testBeforeSendUsesBearerAuthForApiToken()
+    {
+        // Pre-2026 API Token format: 40-char alphanumeric (mixed case).
+        // nosemgrep: generic.secrets.security.detected-generic-api-key.detected-generic-api-key
+        $apiKey = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN';
+        $email = 'test@email.com';
+
+        $this->mockDataStore->method('getClientV4APIKey')->willReturn($apiKey);
+        $this->mockDataStore->method('getCloudFlareEmail')->willReturn($email);
+
+        $request = new \Cloudflare\APO\API\Request(null, null, null, null);
+        $beforeSendRequest = $this->mockClientAPI->beforeSend($request);
+
+        $headers = $beforeSendRequest->getHeaders();
+
+        $this->assertSame("Bearer {$apiKey}", $headers[Client::AUTHORIZATION]);
+        $this->assertArrayNotHasKey(Client::X_AUTH_KEY, $headers);
+        $this->assertArrayNotHasKey(Client::X_AUTH_EMAIL, $headers);
+    }
+
+    /**
+     * @dataProvider providerIsGlobalApiKey
+     */
+    public function testIsGlobalApiKey($key, $expected, $description)
+    {
+        $this->assertSame(
+            $expected,
+            Client::isGlobalApiKey($key),
+            $description
+        );
+    }
+
+    public function providerIsGlobalApiKey()
+    {
+        return array(
+            // New scannable Global API Key format.
+            'new cfk_ Global API Key' => array(
+                'cfk_' . str_repeat('a', 40) . 'X1y2',
+                true,
+                'cfk_-prefixed Global API Key should be detected as Global API Key',
+            ),
+            // New scannable API Token formats.
+            'new cfut_ User API Token' => array(
+                'cfut_' . str_repeat('a', 40) . 'X1y2',
+                false,
+                'cfut_-prefixed User API Token should be sent as Bearer',
+            ),
+            'new cfat_ Account API Token' => array(
+                'cfat_' . str_repeat('b', 40) . 'X1y2',
+                false,
+                'cfat_-prefixed Account API Token should be sent as Bearer',
+            ),
+            // Pre-2026 Global API Key format: 37-45 lowercase hex characters.
+            'pre-2026 Global API Key (37 chars hex)' => array(
+                str_repeat('a', 37),
+                true,
+                '37-char lowercase hex matches legacy Global API Key format',
+            ),
+            'pre-2026 Global API Key (40 chars hex)' => array(
+                str_repeat('a', 40),
+                true,
+                '40-char lowercase hex matches legacy Global API Key format',
+            ),
+            'pre-2026 Global API Key (45 chars hex)' => array(
+                str_repeat('a', 45),
+                true,
+                '45-char lowercase hex matches legacy Global API Key format',
+            ),
+            'lowercase hex outside 37-45 range' => array(
+                str_repeat('a', 48),
+                false,
+                'Hex strings outside the 37-45 range are not Global API Keys',
+            ),
+            // Pre-2026 API Token format: 40-char alphanumeric, mixed case.
+            'pre-2026 API Token (40 char mixed case)' => array(
+                'abcdefghijklmnopqrstuvwxyz0123456789ABCD',
+                false,
+                '40-char alphanumeric (mixed case) is an API Token',
+            ),
+            // Defensive cases.
+            'empty string' => array(
+                '',
+                false,
+                'Empty credential should not be treated as Global API Key',
+            ),
+        );
+    }
+
     public function testClientApiErrorReturnsValidStructure()
     {
         $expectedErrorResponse = array(


### PR DESCRIPTION
## Summary

Recognize Cloudflare's new prefixed credential formats in
`Client::beforeSend()` so that new-format Global API Keys (`cfk_…`)
authenticate via `X-Auth-Email` + `X-Auth-Key` instead of being sent
as `Authorization: Bearer …` (which the Cloudflare API rejects for
Global API Keys).

Also fixes an under-match for pre-2026 Global API Keys: the documented
legacy format is 37–45 lowercase hex characters, but the existing
heuristic only accepts exactly 37.

## Background

Today `Client::beforeSend()` decides between Global-API-Key auth and
API-Token auth using this heuristic:

```php
if (strlen($key) === self::AUTH_KEY_LEN /* 37 */
    && preg_match('/^[0-9a-f]+$/', $key)) {
    $headers[self::X_AUTH_EMAIL] = $this->data_store->getCloudFlareEmail();
    $headers[self::X_AUTH_KEY] = $key;
} else {
    $headers[self::AUTHORIZATION] = "Bearer {$key}";
}
```

Cloudflare introduced [scannable, prefixed credential formats][docs]:

| Credential type        | Format                          |
| ---------------------- | ------------------------------- |
| Global API Key (new)   | `cfk_`  + 40 chars + checksum   |
| User API Token (new)   | `cfut_` + 40 chars + checksum   |
| Account API Token (new)| `cfat_` + 40 chars + checksum   |
| Global API Key (legacy)| 37–45 char lowercase hex string |
| API Token (legacy)     | 40-char alphanumeric            |

[docs]: https://developers.cloudflare.com/fundamentals/api/get-started/token-formats/

A new-format Global API Key (~45 chars, contains `_` and mixed case)
fails both clauses of the heuristic, so the plugin sends it as
`Authorization: Bearer cfk_…`. The Cloudflare API rejects that scheme
for Global API Keys, the test `GET zones/` call in
`AbstractPluginActions::login()` returns an error, and the plugin
surfaces the generic "Email address or API key invalid." message.

## Changes

- Extract the credential-format detection into a static
  `Client::isGlobalApiKey()` helper.
- Recognize the new prefixed formats explicitly:
  - `cfk_…` → Global API Key (use `X-Auth-Email` + `X-Auth-Key`)
  - `cfut_…` / `cfat_…` → API Token (use `Authorization: Bearer`)
- Accept the full 37–45 lowercase-hex range for pre-2026 Global API
  Keys (the previous check only accepted exactly 37 chars).
- Anything else continues to be treated as an API Token and sent as
  `Authorization: Bearer …` (no behavior change for legacy 40-char
  alphanumeric tokens).

## Tests

Added `src/Test/API/ClientTest.php` cases:

- `testBeforeSendUsesGlobalKeyHeadersForCfkPrefix`: a `cfk_…` key sets
  `X-Auth-Email` + `X-Auth-Key` and does not set `Authorization`.
- `testBeforeSendUsesBearerAuthForApiToken`: a 40-char alphanumeric
  API Token sets `Authorization: Bearer …` and does not set the
  Global-API-Key headers.
- `testIsGlobalApiKey` (data provider): `cfk_`, `cfut_`, `cfat_`,
  pre-2026 hex at 37/40/45 chars, out-of-range hex (48 chars),
  pre-2026 alphanumeric token, empty input.

Full local test run on `php:7.4-cli`: **99 tests, 206 assertions, all
passing**. PHPCS clean against the repo's `phpcs.xml` standard.

## Manual verification

Reproduced the failure on a clean WordPress install with plugin
v4.14.2 from wordpress.org using a `cfk_`-prefixed Global API Key:
got the "Email address or API key invalid." error. With this patch
applied to the plugin in the same environment, the same credential
authenticates successfully against `api.cloudflare.com`.
