### PR TITLE
Follow-up on pull/581

### DIFF
--- a/src/API/Exception/ZoneSettingFailException.php
+++ b/src/API/Exception/ZoneSettingFailException.php
@@ -6,7 +6,7 @@ class ZoneSettingFailException extends CloudFlareException
 {
     protected $message = 'Oops, something went wrong, please try again in a few minutes';
 
-    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, ?\Throwable $previous = null)
     {
         if ($message !== null) {
             $this->message = $message;

--- a/src/Test/API/Exception/ZoneSettingFailExceptionTest.php
+++ b/src/Test/API/Exception/ZoneSettingFailExceptionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Cloudflare\APO\API\Exception\Test;
+
+use Cloudflare\APO\API\Exception\ZoneSettingFailException;
+
+class ZoneSettingFailExceptionTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDefaultMessageIsPreservedForBackwardsCompatibility()
+    {
+        $exception = new ZoneSettingFailException();
+
+        $this->assertSame(
+            'Oops, something went wrong, please try again in a few minutes',
+            $exception->getMessage()
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testCustomMessageOverridesDefault()
+    {
+        $exception = new ZoneSettingFailException('Custom failure message');
+
+        $this->assertSame('Custom failure message', $exception->getMessage());
+    }
+
+    public function testCodeAndPreviousArePassedThroughToParent()
+    {
+        $previous = new \RuntimeException('underlying cause');
+        $exception = new ZoneSettingFailException('boom', 42, $previous);
+
+        $this->assertSame('boom', $exception->getMessage());
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testIsACloudFlareException()
+    {
+        $this->assertInstanceOf(
+            'Cloudflare\APO\API\Exception\CloudFlareException',
+            new ZoneSettingFailException()
+        );
+    }
+}

--- a/src/Test/WordPress/PluginActionsTest.php
+++ b/src/Test/WordPress/PluginActionsTest.php
@@ -132,10 +132,6 @@ class PluginActionsTest extends \PHPUnit\Framework\TestCase
 
     public function testApplyDefaultSettingsContinuesAfterPartialFailure()
     {
-        $this->expectException('\Cloudflare\APO\API\Exception\ZoneSettingFailException');
-        $this->expectExceptionMessageMatches('/hotlink_protection/');
-        $this->expectExceptionMessageMatches('/remaining settings were applied successfully/');
-
         $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
 
         $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
@@ -157,7 +153,16 @@ class PluginActionsTest extends \PHPUnit\Framework\TestCase
         // All 13 settings should be attempted
         $this->mockWordPressClientAPI->expects($this->exactly(13))->method('changeZoneSettings');
 
-        $this->pluginActions->applyDefaultSettings();
+        try {
+            $this->pluginActions->applyDefaultSettings();
+            $this->fail('Expected ZoneSettingFailException was not thrown.');
+        } catch (\Cloudflare\APO\API\Exception\ZoneSettingFailException $e) {
+            $message = $e->getMessage();
+            // Combined assertions, since expectExceptionMessageMatches() is a setter
+            // and a second call would silently overwrite the first.
+            $this->assertStringContainsString('hotlink_protection', $message);
+            $this->assertMatchesRegularExpression('/remaining settings were applied successfully/', $message);
+        }
     }
 
     public function testApplyDefaultSettingsSucceedsWhenAllSettingsPass()

--- a/src/Test/WordPress/PluginActionsTest.php
+++ b/src/Test/WordPress/PluginActionsTest.php
@@ -101,15 +101,17 @@ class PluginActionsTest extends \PHPUnit\Framework\TestCase
         $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
 
         $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(false);
+        // Explicitly drive the early-throw branch via responseOk() returning false,
+        // since the production code branches on responseOk(), not on the raw value.
+        $this->mockWordPressClientAPI->method('responseOk')->willReturn(false);
+        // changeZoneSettings must never be reached when zone details fail.
+        $this->mockWordPressClientAPI->expects($this->never())->method('changeZoneSettings');
 
         $this->pluginActions->applyDefaultSettings();
     }
 
     public function testReturnApplyDefaultSettingsChangeZoneSettingsThrowsWithFailedSettingNames()
     {
-        $this->expectException('\Cloudflare\APO\API\Exception\ZoneSettingFailException');
-        $this->expectExceptionMessageMatches('/Failed to update the following settings/');
-
         $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
 
         $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
@@ -127,7 +129,37 @@ class PluginActionsTest extends \PHPUnit\Framework\TestCase
         // All 13 settings (Free plan) should still be attempted despite failures
         $this->mockWordPressClientAPI->expects($this->exactly(13))->method('changeZoneSettings');
 
-        $this->pluginActions->applyDefaultSettings();
+        try {
+            $this->pluginActions->applyDefaultSettings();
+            $this->fail('Expected ZoneSettingFailException was not thrown.');
+        } catch (\Cloudflare\APO\API\Exception\ZoneSettingFailException $e) {
+            $message = $e->getMessage();
+            $this->assertMatchesRegularExpression('/Failed to update the following settings/', $message);
+            // Every Free-plan setting name should appear in the failure list.
+            $expectedSettings = array(
+                'security_level',
+                'cache_level',
+                'browser_cache_ttl',
+                'always_online',
+                'development_mode',
+                'ipv6',
+                'websockets',
+                'ip_geolocation',
+                'email_obfuscation',
+                'server_side_exclude',
+                'hotlink_protection',
+                'rocket_loader',
+                'automatic_https_rewrites',
+            );
+            foreach ($expectedSettings as $name) {
+                $this->assertStringContainsString($name, $message);
+            }
+            // The list should be comma-separated.
+            $this->assertStringContainsString('security_level, cache_level', $message);
+            // The Account Owned Token hint should be included so users know why
+            // a permitted token may still see endpoint-level failures.
+            $this->assertStringContainsString('Account Owned Token', $message);
+        }
     }
 
     public function testApplyDefaultSettingsContinuesAfterPartialFailure()
@@ -162,6 +194,80 @@ class PluginActionsTest extends \PHPUnit\Framework\TestCase
             // and a second call would silently overwrite the first.
             $this->assertStringContainsString('hotlink_protection', $message);
             $this->assertMatchesRegularExpression('/remaining settings were applied successfully/', $message);
+        }
+    }
+
+    public function testApplyDefaultSettingsContinuesWhenFirstAndLastFreeSettingsFail()
+    {
+        // Regression test for the fail-fast bug: a failure on the very first
+        // setting must not abort the loop, and a later failure must still be
+        // collected. Failing the first and last Free-plan settings exercises
+        // both ends of the loop in a single test.
+        $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
+
+        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
+            array(
+                'result' => array(
+                    'plan' => array(
+                        'legacy_id' => Plans::FREE_PLAN,
+                    ),
+                ),
+            )
+        );
+        $this->mockWordPressClientAPI->method('responseOk')->willReturn(true);
+        $this->mockWordPressClientAPI->method('changeZoneSettings')->willReturnOnConsecutiveCalls(
+            false, // security_level (first)
+            true, true, true, true, true, true, true, true, true, true, true,
+            false  // automatic_https_rewrites (last)
+        );
+        $this->mockWordPressClientAPI->expects($this->exactly(13))->method('changeZoneSettings');
+
+        try {
+            $this->pluginActions->applyDefaultSettings();
+            $this->fail('Expected ZoneSettingFailException was not thrown.');
+        } catch (\Cloudflare\APO\API\Exception\ZoneSettingFailException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('security_level', $message);
+            $this->assertStringContainsString('automatic_https_rewrites', $message);
+            // Settings that succeeded must not appear in the failure list.
+            $this->assertStringNotContainsString('cache_level', $message);
+            $this->assertStringNotContainsString('hotlink_protection', $message);
+        }
+    }
+
+    public function testApplyDefaultSettingsBusinessPlanContinuesAfterPolishFailure()
+    {
+        // Business plan adds `mirage` and `polish` (15 total). Verify the loop
+        // still attempts every setting and only the failing one is reported,
+        // exercising the conditional plan-tier extension of the settings list.
+        $this->mockRequest->method('getUrl')->willReturn('/plugin/:id/settings/default_settings');
+
+        $this->mockWordPressClientAPI->method('zoneGetDetails')->willReturn(
+            array(
+                'result' => array(
+                    'plan' => array(
+                        'legacy_id' => Plans::BIZ_PLAN,
+                    ),
+                ),
+            )
+        );
+        $this->mockWordPressClientAPI->method('responseOk')->willReturn(true);
+        // Only `polish` (15th call, index 14) fails.
+        $this->mockWordPressClientAPI->method('changeZoneSettings')->willReturnOnConsecutiveCalls(
+            true, true, true, true, true, true, true, true, true, true,
+            true, true, true,
+            true,  // mirage
+            false  // polish
+        );
+        $this->mockWordPressClientAPI->expects($this->exactly(15))->method('changeZoneSettings');
+
+        try {
+            $this->pluginActions->applyDefaultSettings();
+            $this->fail('Expected ZoneSettingFailException was not thrown.');
+        } catch (\Cloudflare\APO\API\Exception\ZoneSettingFailException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('polish', $message);
+            $this->assertStringNotContainsString('mirage', $message);
         }
     }
 

--- a/src/WordPress/PluginActions.php
+++ b/src/WordPress/PluginActions.php
@@ -72,6 +72,11 @@ class PluginActions extends AbstractPluginActions
      * PATCH /plugin/:id/settings/default_settings
      *
      * Requests are synchronized
+     *
+     * @throws ZoneSettingFailException When zone details cannot be fetched, or
+     *         when one or more individual zone settings fail to update. In the
+     *         latter case the exception message lists the failed setting names
+     *         and confirms the remaining settings were applied successfully.
      */
     public function applyDefaultSettings()
     {

--- a/src/WordPress/PluginActions.php
+++ b/src/WordPress/PluginActions.php
@@ -89,7 +89,7 @@ class PluginActions extends AbstractPluginActions
             throw new ZoneSettingFailException();
         }
 
-        $currentPlan = $details['result']['plan']['legacy_id'] ?? 'free';
+        $currentPlan = $details['result']['plan']['legacy_id'] ?? Plans::FREE_PLAN;
 
         // Define the recommended settings to apply
         $settings = array(


### PR DESCRIPTION
- Fixed a bug in `testApplyDefaultSettingsContinuesAfterPartialFailure` where the second `expectExceptionMessageMatches()` call silently overwrote the first, making the `hotlink_protection` assertion dead code
- Added tests for: fail-fast regression (first and last setting fail), Business plan partial failure (`polish` only), AOT hint string presence, all-fail message containing every setting name and comma separation, zone-details failure asserting `changeZoneSettings` is never called, and standalone `ZoneSettingFailException` constructor contract (default message, custom override, `$code`/`$previous` pass-through)
- Fixed PHP 8.4 deprecation: `\Throwable $previous = null` replaced with `?\Throwable $previous = null` in `ZoneSettingFailException`
- Added `@throws` docblock to `applyDefaultSettings()` covering both failure paths
- Replaced `'free'` magic string with `Plans::FREE_PLAN` constant