### PR TITLE
Declare permissions on php-build, php, and stale workflows

### DIFF
--- a/.github/workflows/php-build.yml
+++ b/.github/workflows/php-build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build artifact

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Validate

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
 


### PR DESCRIPTION
Three remaining workflows in this repo were inheriting the default `GITHUB_TOKEN` scope. This PR pins each to the minimum it actually needs:

- **php-build.yml** and **php.yml** — `contents: read`. They build the plugin, validate composer files, and run `composer run-script test`/`test-build` over a PHP version matrix. The `actions/upload-artifact` + `actions/download-artifact` steps only write to the run's artifact storage, not to the repo.
- **stale.yml** — `issues: write` + `pull-requests: write` (no `contents` grant). `actions/stale@v3` labels and closes inactive issues and PRs, but doesn't touch repo contents.

Matches the top-level permissions style already used in `release.yml` and `semgrep.yml`. YAML validated locally with `yaml.safe_load`.